### PR TITLE
:sparkles: Implement e2e tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,6 +82,4 @@ jobs:
         sudo apt-get install -y make
 
     - name: Run tests
-      run: |
-        make kustomize
-        make test-e2e
+      run: make test-e2e

--- a/charts/0.1.1/templates/crd/syngit.syngit.io_remotesyncer.yaml
+++ b/charts/0.1.1/templates/crd/syngit.syngit.io_remotesyncer.yaml
@@ -670,10 +670,9 @@ spec:
               defaultBlockAppliedMessage:
                 type: string
               defaultBranch:
+                example: main
                 type: string
-              defaultUnauthorizedUserMode:
-                type: string
-              defaultUser:
+              defaultRemoteUserRef:
                 description: |-
                   ObjectReference contains enough information to let you inspect or modify the referred object.
                   ---
@@ -734,6 +733,12 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
+              defaultUnauthorizedUserMode:
+                default: Block
+                enum:
+                - Block
+                - UseDefaultUser
+                type: string
               excludedFields:
                 items:
                   type: string
@@ -802,15 +807,26 @@ spec:
               insecureSkipTlsVerify:
                 type: boolean
               processMode:
+                default: CommitApply
+                enum:
+                - CommitOnly
+                - CommitApply
                 type: string
               pushMode:
+                default: SameBranch
+                enum:
+                - SameBranch
+                - MultipleBranch
+                - MergeRequest
                 type: string
               remoteRepository:
+                example: https://git.example.com/my-repo.git
                 format: uri
                 type: string
               rootPath:
                 type: string
               scopedResources:
+                default: {}
                 properties:
                   matchPolicy:
                     description: MatchPolicyType specifies the type of match policy.
@@ -943,6 +959,7 @@ spec:
             - processMode
             - pushMode
             - remoteRepository
+            - scopedResources
             type: object
           status:
             properties:
@@ -1162,5 +1179,4 @@ spec:
     storage: true
     subresources:
       status: {}
-
 {{- end }}

--- a/internal/controller/webhook_request_checker.go
+++ b/internal/controller/webhook_request_checker.go
@@ -124,7 +124,7 @@ func (wrc *WebhookRequestChecker) ProcessSteps() admissionv1.AdmissionReview {
 		return wrc.responseConstructor(rDetails)
 	}
 
-	// STEP 5 : Post checking
+	// STEP 7 : Post checking
 	wrc.postcheck(&rDetails)
 
 	return wrc.responseConstructor(rDetails)

--- a/internal/webhook/v1beta2/remoteuser_association_webhook.go
+++ b/internal/webhook/v1beta2/remoteuser_association_webhook.go
@@ -6,7 +6,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -28,69 +27,13 @@ func (ruwh *RemoteUserWebhookHandler) Handle(ctx context.Context, req admission.
 	name := syngit.RubPrefix + username
 
 	if string(req.Operation) == "DELETE" {
-		ru := &syngit.RemoteUser{}
-		err := ruwh.Decoder.DecodeRaw(req.OldObject, ru)
-		if err != nil {
-			return admission.Errored(http.StatusBadRequest, err)
-		}
-
-		rub := &syngit.RemoteUserBinding{}
-		webhookNamespacedName := &types.NamespacedName{
-			Name:      name,
-			Namespace: req.Namespace,
-		}
-		rubErr := ruwh.Client.Get(ctx, *webhookNamespacedName, rub)
-		if rubErr != nil {
-			return admission.Errored(http.StatusBadRequest, rubErr)
-		}
-
-		isControlled := false
-		ownerRefs := rub.ObjectMeta.DeepCopy().OwnerReferences
-		newOwnerRefs := []v1.OwnerReference{}
-		for _, owner := range ownerRefs {
-			if string(owner.UID) != string(ru.UID) {
-				newOwnerRefs = append(newOwnerRefs, owner)
-			} else {
-				isControlled = true
-			}
-		}
-		rub.ObjectMeta.OwnerReferences = newOwnerRefs
-
-		remoteRefs := rub.Spec.DeepCopy().RemoteRefs
-		newRemoteRefs := []corev1.ObjectReference{}
-		for _, rm := range remoteRefs {
-			if (rm.Name != ru.Name && isControlled) || !isControlled {
-				newRemoteRefs = append(newRemoteRefs, rm)
-			}
-		}
-		rub.Spec.RemoteRefs = newRemoteRefs
-
-		if len(newRemoteRefs) != 0 {
-
-			deleteErr := ruwh.Client.Update(ctx, rub)
-			if deleteErr != nil {
-				return admission.Errored(http.StatusInternalServerError, deleteErr)
-			}
-
-		} else {
-
-			deleteErr := ruwh.Client.Delete(ctx, rub)
-			if deleteErr != nil {
-				return admission.Errored(http.StatusInternalServerError, deleteErr)
-			}
-		}
-
-		return admission.Allowed("This object is not associated with the " + name + " RemoteUserBinding anymore")
+		return ruwh.removeRuFromRub(ctx, req, name)
 	}
 
 	ru := &syngit.RemoteUser{}
 	err := ruwh.Decoder.Decode(req, ru)
 	if err != nil {
 		return admission.Errored(http.StatusBadRequest, err)
-	}
-
-	if ru.Annotations["syngit.syngit.io/associated-remote-userbinding"] == "" || ru.Annotations["syngit.syngit.io/associated-remote-userbinding"] == "false" {
-		return admission.Allowed("This object is not associated with any RemoteUserBinding")
 	}
 
 	objRef := corev1.ObjectReference{Name: ru.Name}
@@ -102,20 +45,13 @@ func (ruwh *RemoteUserWebhookHandler) Handle(ctx context.Context, req admission.
 	err = ruwh.Client.Get(ctx, *webhookNamespacedName, rub)
 	if err != nil {
 		// The RemoteUserBinding does not exists yet
+		if ru.Annotations["syngit.syngit.io/associated-remote-userbinding"] == "" || ru.Annotations["syngit.syngit.io/associated-remote-userbinding"] == "false" {
+			return admission.Allowed("This object is not associated with any RemoteUserBinding")
+		}
 
 		// Create the RemoteUserBinding object
 		rub.Name = name
 		rub.Namespace = req.Namespace
-
-		// ownerRef := v1.OwnerReference{
-		// 	Name:       ru.Name,
-		// 	APIVersion: ru.APIVersion,
-		// 	Kind:       ru.GroupVersionKind().Kind,
-		// 	UID:        ru.GetUID(),
-		// }
-		// ownerRefs := make([]v1.OwnerReference, 0)
-		// ownerRefs = append(ownerRefs, ownerRef)
-		// rub.ObjectMeta.OwnerReferences = ownerRefs
 
 		subject := &rbacv1.Subject{
 			Kind: "User",
@@ -133,17 +69,9 @@ func (ruwh *RemoteUserWebhookHandler) Handle(ctx context.Context, req admission.
 		}
 	} else {
 		// The RemoteUserBinding already exists
-
-		// Update the list of the RemoteUserBinding object
-		// ownerRef := v1.OwnerReference{
-		// 	Name:       ru.Name,
-		// 	APIVersion: ru.APIVersion,
-		// 	Kind:       ru.GroupVersionKind().Kind,
-		// 	UID:        ru.GetUID(),
-		// }
-		// ownerRefs := rub.ObjectMeta.DeepCopy().OwnerReferences
-		// ownerRefs = append(ownerRefs, ownerRef)
-		// rub.ObjectMeta.OwnerReferences = ownerRefs
+		if ru.Annotations["syngit.syngit.io/associated-remote-userbinding"] == "" || ru.Annotations["syngit.syngit.io/associated-remote-userbinding"] == "false" {
+			return ruwh.removeRuFromRub(ctx, req, name)
+		}
 
 		remoteRefs := rub.DeepCopy().Spec.RemoteRefs
 		remoteRefs = append(remoteRefs, objRef)
@@ -157,4 +85,48 @@ func (ruwh *RemoteUserWebhookHandler) Handle(ctx context.Context, req admission.
 	}
 
 	return admission.Allowed("This object is associated to the " + name + " RemoteUserBinding")
+}
+
+func (ruwh *RemoteUserWebhookHandler) removeRuFromRub(ctx context.Context, req admission.Request, name string) admission.Response {
+	ru := &syngit.RemoteUser{}
+	err := ruwh.Decoder.DecodeRaw(req.OldObject, ru)
+	if err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	rub := &syngit.RemoteUserBinding{}
+	webhookNamespacedName := &types.NamespacedName{
+		Name:      name,
+		Namespace: req.Namespace,
+	}
+	rubErr := ruwh.Client.Get(ctx, *webhookNamespacedName, rub)
+	if rubErr != nil {
+		return admission.Errored(http.StatusBadRequest, rubErr)
+	}
+
+	remoteRefs := rub.Spec.DeepCopy().RemoteRefs
+	newRemoteRefs := []corev1.ObjectReference{}
+	for _, rm := range remoteRefs {
+		if rm.Name != ru.Name {
+			newRemoteRefs = append(newRemoteRefs, rm)
+		}
+	}
+	rub.Spec.RemoteRefs = newRemoteRefs
+
+	if len(newRemoteRefs) != 0 {
+
+		deleteErr := ruwh.Client.Update(ctx, rub)
+		if deleteErr != nil {
+			return admission.Errored(http.StatusInternalServerError, deleteErr)
+		}
+
+	} else {
+
+		deleteErr := ruwh.Client.Delete(ctx, rub)
+		if deleteErr != nil {
+			return admission.Errored(http.StatusInternalServerError, deleteErr)
+		}
+	}
+
+	return admission.Allowed("This object is not associated with the " + name + " RemoteUserBinding anymore")
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -18,16 +18,11 @@ package e2e_build
 
 import (
 	"fmt"
-	"os/exec"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	"syngit.io/syngit/test/utils"
 )
-
-const namespace = "syngit-system"
 
 // Run e2e tests using the Ginkgo runner.
 func TestE2E(t *testing.T) {
@@ -38,13 +33,7 @@ func TestE2E(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 
-	By("creating manager namespace")
-	cmd := exec.Command("kubectl", "create", "ns", namespace)
-	_, _ = utils.Run(cmd)
 })
 
 var _ = AfterSuite(func() {
-	By("removing manager namespace")
-	cmd := exec.Command("kubectl", "delete", "ns", namespace)
-	_, _ = utils.Run(cmd)
 })

--- a/test/e2e/syngit/02_commitonly_cm_test.go
+++ b/test/e2e/syngit/02_commitonly_cm_test.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e_syngit
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	admissionv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	syngit "syngit.io/syngit/api/v1beta2"
+	. "syngit.io/syngit/test/utils"
+)
+
+var _ = Describe("02 CommitOnly a ConfigMap", func() {
+	ctx := context.TODO()
+
+	const (
+		cmName               = "test-cm2"
+		remoteUserLufffyName = "remoteuser-luffy"
+		remoteSyncerName     = "remotesyncer-test"
+	)
+
+	It("should not create the resource on the cluster", func() {
+		By("adding syngit to scheme")
+		err := syngit.AddToScheme(scheme.Scheme)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("creating the RemoteUser & RemoteUserBinding for Luffy")
+		luffySecretName := string(Luffy) + "-creds"
+		remoteUserLuffy := &syngit.RemoteUser{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      remoteUserLufffyName,
+				Namespace: namespace,
+				Annotations: map[string]string{
+					"syngit.syngit.io/associated-remote-userbinding": "true",
+				},
+			},
+			Spec: syngit.RemoteUserSpec{
+				Email:             "sample@email.com",
+				GitBaseDomainFQDN: GitP1Fqdn,
+				SecretRef: corev1.SecretReference{
+					Name: luffySecretName,
+				},
+			},
+		}
+		Eventually(func() bool {
+			err := sClient.As(Luffy).CreateOrUpdate(remoteUserLuffy)
+			return err == nil
+		}, timeout, interval).Should(BeTrue())
+
+		Wait5()
+		repoUrl := "http://" + GitP1Fqdn + "/syngituser/blue.git"
+		By("creating the RemoteSyncer")
+		remotesyncer := &syngit.RemoteSyncer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      remoteSyncerName,
+				Namespace: namespace,
+			},
+			Spec: syngit.RemoteSyncerSpec{
+				DefaultBlockAppliedMessage:  defaultDeniedMessage,
+				DefaultBranch:               "main",
+				DefaultUnauthorizedUserMode: syngit.Block,
+				ExcludedFields:              []string{".metadata.uid"},
+				ProcessMode:                 syngit.CommitOnly,
+				PushMode:                    syngit.SameBranch,
+				RemoteRepository:            repoUrl,
+				ScopedResources: syngit.ScopedResources{
+					Rules: []admissionv1.RuleWithOperations{{
+						Operations: []admissionv1.OperationType{
+							admissionv1.Create,
+						},
+						Rule: admissionv1.Rule{
+							APIGroups:   []string{""},
+							APIVersions: []string{"v1"},
+							Resources:   []string{"configmaps"},
+						},
+					},
+					},
+				},
+			},
+		}
+		Eventually(func() bool {
+			err := sClient.As(Luffy).CreateOrUpdate(remotesyncer)
+			return err == nil
+		}, timeout, interval).Should(BeTrue())
+
+		Wait5()
+		By("creating a test configmap")
+		cm := &corev1.ConfigMap{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "ConfigMap",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{Name: cmName, Namespace: namespace},
+			Data:       map[string]string{"test": "oui"},
+		}
+		_, err = sClient.KAs(Luffy).CoreV1().ConfigMaps(namespace).Create(ctx,
+			cm,
+			metav1.CreateOptions{},
+		)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring(defaultDeniedMessage))
+
+		By("checking if the configmap is present on the repo")
+		repo := &Repo{
+			Fqdn:  GitP1Fqdn,
+			Owner: "syngituser",
+			Name:  "blue",
+		}
+		exists, err := IsObjectInRepo(*repo, cm)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(exists).To(BeTrue())
+
+		By("checking that the configmap is not present on the cluster")
+		nnCm := types.NamespacedName{
+			Name:      cmName,
+			Namespace: namespace,
+		}
+		getCm := &corev1.ConfigMap{}
+
+		Wait10()
+		err = sClient.As(Luffy).Get(nnCm, getCm)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("not found"))
+
+		By("deleting the remote syncer from the cluster")
+		Eventually(func() bool {
+			err := sClient.As(Luffy).Delete(remotesyncer)
+			return err == nil
+		}, timeout, interval).Should(BeTrue())
+	})
+})

--- a/test/e2e/syngit/03_commitapply_cm_test.go
+++ b/test/e2e/syngit/03_commitapply_cm_test.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e_syngit
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	admissionv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	syngit "syngit.io/syngit/api/v1beta2"
+	. "syngit.io/syngit/test/utils"
+)
+
+var _ = Describe("03 CommitApply a ConfigMap", func() {
+	ctx := context.TODO()
+
+	const (
+		remoteSyncerName    = "remotesyncer-test"
+		remoteUserLuffyName = "remoteuser-luffy"
+		cmName              = "test-cm3"
+	)
+
+	It("should create the resource on the git repo and on the cluster", func() {
+		By("adding syngit to scheme")
+		err := syngit.AddToScheme(scheme.Scheme)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("creating the RemoteUser & RemoteUserBinding for Luffy")
+		luffySecretName := string(Luffy) + "-creds"
+		remoteUserLuffy := &syngit.RemoteUser{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      remoteUserLuffyName,
+				Namespace: namespace,
+				Annotations: map[string]string{
+					"syngit.syngit.io/associated-remote-userbinding": "true",
+				},
+			},
+			Spec: syngit.RemoteUserSpec{
+				Email:             "sample@email.com",
+				GitBaseDomainFQDN: GitP1Fqdn,
+				SecretRef: corev1.SecretReference{
+					Name: luffySecretName,
+				},
+			},
+		}
+		Eventually(func() bool {
+			err := sClient.As(Luffy).CreateOrUpdate(remoteUserLuffy)
+			return err == nil
+		}, timeout, interval).Should(BeTrue())
+
+		Wait5()
+		repoUrl := "http://" + GitP1Fqdn + "/syngituser/blue.git"
+		By("creating the RemoteSyncer")
+		remotesyncer := &syngit.RemoteSyncer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      remoteSyncerName,
+				Namespace: namespace,
+			},
+			Spec: syngit.RemoteSyncerSpec{
+				DefaultBranch:               "main",
+				DefaultUnauthorizedUserMode: syngit.Block,
+				ExcludedFields:              []string{".metadata.uid"},
+				ProcessMode:                 syngit.CommitApply,
+				PushMode:                    syngit.SameBranch,
+				RemoteRepository:            repoUrl,
+				ScopedResources: syngit.ScopedResources{
+					Rules: []admissionv1.RuleWithOperations{{
+						Operations: []admissionv1.OperationType{
+							admissionv1.Create,
+						},
+						Rule: admissionv1.Rule{
+							APIGroups:   []string{""},
+							APIVersions: []string{"v1"},
+							Resources:   []string{"configmaps"},
+						},
+					},
+					},
+				},
+			},
+		}
+		Eventually(func() bool {
+			err := sClient.As(Luffy).CreateOrUpdate(remotesyncer)
+			return err == nil
+		}, timeout, interval).Should(BeTrue())
+
+		Wait5()
+		By("creating a test configmap")
+		cm := &corev1.ConfigMap{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "ConfigMap",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{Name: cmName, Namespace: namespace},
+			Data:       map[string]string{"test": "oui"},
+		}
+		_, err = sClient.KAs(Luffy).CoreV1().ConfigMaps(namespace).Create(ctx,
+			cm,
+			metav1.CreateOptions{},
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("checking if the configmap is present on the repo")
+		repo := &Repo{
+			Fqdn:  GitP1Fqdn,
+			Owner: "syngituser",
+			Name:  "blue",
+		}
+		exists, err := IsObjectInRepo(*repo, cm)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(exists).To(BeTrue())
+
+		By("checking that the configmap is present on the cluster")
+		nnCm := types.NamespacedName{
+			Name:      cmName,
+			Namespace: namespace,
+		}
+		getCm := &corev1.ConfigMap{}
+
+		Eventually(func() bool {
+			err := sClient.As(Luffy).Get(nnCm, getCm)
+			return err == nil
+		}, timeout, interval).Should(BeTrue())
+
+		By("deleting the configmap from the cluster")
+		Eventually(func() bool {
+			err := sClient.As(Luffy).Delete(getCm)
+			return err == nil
+		}, timeout, interval).Should(BeTrue())
+
+		By("deleting the remote syncer from the cluster")
+		Eventually(func() bool {
+			err := sClient.As(Luffy).Delete(remotesyncer)
+			return err == nil
+		}, timeout, interval).Should(BeTrue())
+	})
+})

--- a/test/e2e/syngit/04_excludedfields_test.go
+++ b/test/e2e/syngit/04_excludedfields_test.go
@@ -1,0 +1,317 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e_syngit
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"gopkg.in/yaml.v2"
+	admissionv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	syngit "syngit.io/syngit/api/v1beta2"
+	. "syngit.io/syngit/test/utils"
+)
+
+var _ = Describe("04 Create RemoteSyncer with excluded fields", func() {
+	ctx := context.TODO()
+
+	const (
+		cmName1             = "test-cm4.1"
+		cmName2             = "test-cm4.2"
+		remoteUserLuffyName = "remoteuser-luffy"
+		remoteSyncerName    = "remotesyncer-test"
+	)
+
+	It("should exclude the selected fields from the git repo", func() {
+		By("adding syngit to scheme")
+		err := syngit.AddToScheme(scheme.Scheme)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("creating the RemoteUser & RemoteUserBinding for Luffy")
+		luffySecretName := string(Luffy) + "-creds"
+		remoteUserLuffy := &syngit.RemoteUser{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      remoteUserLuffyName,
+				Namespace: namespace,
+				Annotations: map[string]string{
+					"syngit.syngit.io/associated-remote-userbinding": "true",
+				},
+			},
+			Spec: syngit.RemoteUserSpec{
+				Email:             "sample@email.com",
+				GitBaseDomainFQDN: GitP1Fqdn,
+				SecretRef: corev1.SecretReference{
+					Name: luffySecretName,
+				},
+			},
+		}
+		Eventually(func() bool {
+			err := sClient.As(Luffy).CreateOrUpdate(remoteUserLuffy)
+			return err == nil
+		}, timeout, interval).Should(BeTrue())
+
+		Wait5()
+		repoUrl := "http://" + GitP1Fqdn + "/syngituser/blue.git"
+		By("creating the RemoteSyncer")
+		remotesyncer := &syngit.RemoteSyncer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      remoteSyncerName,
+				Namespace: namespace,
+			},
+			Spec: syngit.RemoteSyncerSpec{
+				DefaultBlockAppliedMessage:  defaultDeniedMessage,
+				DefaultBranch:               "main",
+				DefaultUnauthorizedUserMode: syngit.Block,
+				ExcludedFields: []string{
+					".metadata.uid",
+					"metadata.managedFields",
+					"metadata.annotations[test-annotation1]",
+					"metadata.annotations.[test-annotation2]",
+				},
+				ProcessMode:      syngit.CommitOnly,
+				PushMode:         syngit.SameBranch,
+				RemoteRepository: repoUrl,
+				ScopedResources: syngit.ScopedResources{
+					Rules: []admissionv1.RuleWithOperations{{
+						Operations: []admissionv1.OperationType{
+							admissionv1.Create,
+						},
+						Rule: admissionv1.Rule{
+							APIGroups:   []string{""},
+							APIVersions: []string{"v1"},
+							Resources:   []string{"configmaps"},
+						},
+					},
+					},
+				},
+			},
+		}
+		Eventually(func() bool {
+			err := sClient.As(Luffy).CreateOrUpdate(remotesyncer)
+			return err == nil
+		}, timeout, interval).Should(BeTrue())
+
+		Wait5()
+		By("creating a test configmap")
+		const (
+			annotation1Key = "test-annotation1"
+			annotation2Key = "test-annotation2"
+			annotation3Key = "test-annotation3"
+		)
+		cm := &corev1.ConfigMap{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "ConfigMap",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{Name: cmName1, Namespace: namespace, Annotations: map[string]string{
+				annotation1Key: "test",
+				annotation2Key: "test",
+				annotation3Key: "test",
+			}},
+			Data: map[string]string{"test": "oui"},
+		}
+		_, err = sClient.KAs(Luffy).CoreV1().ConfigMaps(namespace).Create(ctx,
+			cm,
+			metav1.CreateOptions{},
+		)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring(defaultDeniedMessage))
+
+		By("checking if the right fields are present on the ConfigMap on the repo")
+		repo := &Repo{
+			Fqdn:  GitP1Fqdn,
+			Owner: "syngituser",
+			Name:  "blue",
+		}
+		uidExists, err := IsFieldDefined(*repo, cm, "metadata.uid")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(uidExists).To(BeFalse())
+		managedFieldsExists, err := IsFieldDefined(*repo, cm, "metadata.managedFields")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(managedFieldsExists).To(BeFalse())
+
+		tree, err := GetRepoTree(*repo)
+		Expect(err).ToNot(HaveOccurred())
+		getCm, err := GetObjectInRepo(*repo, tree, cm)
+		Expect(err).ToNot(HaveOccurred())
+		var parsed map[interface{}]interface{}
+		err = yaml.Unmarshal(getCm.Content, &parsed)
+		Expect(err).ToNot(HaveOccurred())
+		metadata := parsed["metadata"].(map[interface{}]interface{})
+		annotations := metadata["annotations"].(map[interface{}]interface{})
+		annotation1 := annotations[annotation1Key]
+		Expect(annotation1).To(BeNil())
+		annotation2 := annotations[annotation2Key]
+		Expect(annotation2).To(BeNil())
+		annotation3 := annotations[annotation3Key]
+		Expect(annotation3).To(Equal("test"))
+
+		By("deleting the remote syncer from the cluster")
+		Eventually(func() bool {
+			err := sClient.As(Luffy).Delete(remotesyncer)
+			return err == nil
+		}, timeout, interval).Should(BeTrue())
+	})
+
+	It("should exclude the fields (configured in the ConfigMap) from the git repo", func() {
+		By("adding syngit to scheme")
+		err := syngit.AddToScheme(scheme.Scheme)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("creating the RemoteUser & RemoteUserBinding for Luffy")
+		luffySecretName := string(Luffy) + "-creds"
+		remoteUserLuffy := &syngit.RemoteUser{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "remoteuser-luffy",
+				Namespace: namespace,
+				Annotations: map[string]string{
+					"syngit.syngit.io/associated-remote-userbinding": "true",
+				},
+			},
+			Spec: syngit.RemoteUserSpec{
+				Email:             "sample@email.com",
+				GitBaseDomainFQDN: GitP1Fqdn,
+				SecretRef: corev1.SecretReference{
+					Name: luffySecretName,
+				},
+			},
+		}
+		Eventually(func() bool {
+			err := sClient.As(Luffy).CreateOrUpdate(remoteUserLuffy)
+			return err == nil
+		}, timeout, interval).Should(BeTrue())
+
+		const excludedFieldsConfiMapName = "excluded-fields"
+		excludedFieldsConfiMap := &corev1.ConfigMap{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "ConfigMap",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{Name: excludedFieldsConfiMapName, Namespace: namespace},
+			Data: map[string]string{
+				"excludedFields": "[\"metadata.uid\", \"metadata.managedFields\", \"metadata.annotations[test-annotation1]\", \"metadata.annotations.[test-annotation2]\"]",
+			},
+		}
+		_, err = sClient.KAs(Luffy).CoreV1().ConfigMaps(namespace).Create(ctx,
+			excludedFieldsConfiMap,
+			metav1.CreateOptions{},
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		Wait5()
+		repoUrl := "http://" + GitP1Fqdn + "/syngituser/blue.git"
+		By("creating the RemoteSyncer")
+		remotesyncer := &syngit.RemoteSyncer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "remotesyncer-test",
+				Namespace: namespace,
+			},
+			Spec: syngit.RemoteSyncerSpec{
+				DefaultBlockAppliedMessage:  defaultDeniedMessage,
+				DefaultBranch:               "main",
+				DefaultUnauthorizedUserMode: syngit.Block,
+				ExcludedFieldsConfigMapRef: &corev1.ObjectReference{
+					Name:      excludedFieldsConfiMapName,
+					Namespace: namespace,
+				},
+				ProcessMode:      syngit.CommitOnly,
+				PushMode:         syngit.SameBranch,
+				RemoteRepository: repoUrl,
+				ScopedResources: syngit.ScopedResources{
+					Rules: []admissionv1.RuleWithOperations{{
+						Operations: []admissionv1.OperationType{
+							admissionv1.Create,
+						},
+						Rule: admissionv1.Rule{
+							APIGroups:   []string{""},
+							APIVersions: []string{"v1"},
+							Resources:   []string{"configmaps"},
+						},
+					},
+					},
+				},
+			},
+		}
+		Eventually(func() bool {
+			err := sClient.As(Luffy).CreateOrUpdate(remotesyncer)
+			return err == nil
+		}, timeout, interval).Should(BeTrue())
+
+		Wait5()
+		By("creating a test configmap")
+		const annotation1Key = "test-annotation1"
+		const annotation2Key = "test-annotation2"
+		const annotation3Key = "test-annotation3"
+		cm := &corev1.ConfigMap{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "ConfigMap",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{Name: cmName2, Namespace: namespace, Annotations: map[string]string{
+				annotation1Key: "test",
+				annotation2Key: "test",
+				annotation3Key: "test",
+			}},
+			Data: map[string]string{"test": "oui"},
+		}
+		_, err = sClient.KAs(Luffy).CoreV1().ConfigMaps(namespace).Create(ctx,
+			cm,
+			metav1.CreateOptions{},
+		)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring(defaultDeniedMessage))
+
+		By("checking if the right fields are present on the ConfigMap on the repo")
+		repo := &Repo{
+			Fqdn:  GitP1Fqdn,
+			Owner: "syngituser",
+			Name:  "blue",
+		}
+		uidExists, err := IsFieldDefined(*repo, cm, "metadata.uid")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(uidExists).To(BeFalse())
+		managedFieldsExists, err := IsFieldDefined(*repo, cm, "metadata.managedFields")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(managedFieldsExists).To(BeFalse())
+
+		tree, err := GetRepoTree(*repo)
+		Expect(err).ToNot(HaveOccurred())
+		getCm, err := GetObjectInRepo(*repo, tree, cm)
+		Expect(err).ToNot(HaveOccurred())
+		var parsed map[interface{}]interface{}
+		err = yaml.Unmarshal(getCm.Content, &parsed)
+		Expect(err).ToNot(HaveOccurred())
+		metadata := parsed["metadata"].(map[interface{}]interface{})
+		annotations := metadata["annotations"].(map[interface{}]interface{})
+		annotation1 := annotations[annotation1Key]
+		Expect(annotation1).To(BeNil())
+		annotation2 := annotations[annotation2Key]
+		Expect(annotation2).To(BeNil())
+		annotation3 := annotations[annotation3Key]
+		Expect(annotation3).To(Equal("test"))
+
+		By("deleting the remote syncer from the cluster")
+		Eventually(func() bool {
+			err := sClient.As(Luffy).Delete(remotesyncer)
+			return err == nil
+		}, timeout, interval).Should(BeTrue())
+	})
+})

--- a/test/e2e/syngit/05_defaultuser_test.go
+++ b/test/e2e/syngit/05_defaultuser_test.go
@@ -1,0 +1,217 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e_syngit
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	admissionv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	syngit "syngit.io/syngit/api/v1beta2"
+	. "syngit.io/syngit/test/utils"
+)
+
+var _ = Describe("05 Use a default user", func() {
+	ctx := context.TODO()
+
+	const (
+		cmName                = "test-cm5"
+		remoteUserLuffyName   = "remoteuser-luffy"
+		remoteUserChopperName = "remoteuser-chopper"
+		remoteUserSanjiName   = "remoteuser-sanji"
+		remoteSyncerName      = "remotesyncer-test5"
+	)
+
+	It("should use the default user to push the resource", func() {
+		By("adding syngit to scheme")
+		err := syngit.AddToScheme(scheme.Scheme)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("only creating the RemoteUser for Luffy")
+		luffySecretName := string(Luffy) + "-creds"
+		remoteUserLuffy := &syngit.RemoteUser{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      remoteUserLuffyName,
+				Namespace: namespace,
+			},
+			Spec: syngit.RemoteUserSpec{
+				Email:             "sample@email.com",
+				GitBaseDomainFQDN: GitP1Fqdn,
+				SecretRef: corev1.SecretReference{
+					Name: luffySecretName,
+				},
+			},
+		}
+		Eventually(func() bool {
+			err := sClient.As(Luffy).CreateOrUpdate(remoteUserLuffy)
+			return err == nil
+		}, timeout, interval).Should(BeTrue())
+
+		By("only creating the RemoteUser for Chopper")
+		chopperSecretName := string(Chopper) + "-creds"
+		remoteUserChopper := &syngit.RemoteUser{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      remoteUserChopperName,
+				Namespace: namespace,
+			},
+			Spec: syngit.RemoteUserSpec{
+				Email:             "sample@email.com",
+				GitBaseDomainFQDN: GitP1Fqdn,
+				SecretRef: corev1.SecretReference{
+					Name: chopperSecretName,
+				},
+			},
+		}
+		Eventually(func() bool {
+			err := sClient.As(Chopper).CreateOrUpdate(remoteUserChopper)
+			return err == nil
+		}, timeout, interval).Should(BeTrue())
+
+		By("creating the RemoteUser & RemoteUserBinding for Sanji")
+		sanjiSecretName := string(Sanji) + "-creds"
+		remoteUserSanji := &syngit.RemoteUser{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      remoteUserSanjiName,
+				Namespace: namespace,
+				Annotations: map[string]string{
+					"syngit.syngit.io/associated-remote-userbinding": "true",
+				},
+			},
+			Spec: syngit.RemoteUserSpec{
+				Email:             "sample@email.com",
+				GitBaseDomainFQDN: GitP1Fqdn,
+				SecretRef: corev1.SecretReference{
+					Name: sanjiSecretName,
+				},
+			},
+		}
+		Eventually(func() bool {
+			err := sClient.As(Sanji).CreateOrUpdate(remoteUserSanji)
+			return err == nil
+		}, timeout, interval).Should(BeTrue())
+
+		Wait5()
+		repoUrl := "http://" + GitP1Fqdn + "/syngituser/green.git"
+		By("creating the RemoteSyncer")
+		remotesyncer := &syngit.RemoteSyncer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      remoteSyncerName,
+				Namespace: namespace,
+			},
+			Spec: syngit.RemoteSyncerSpec{
+				DefaultBranch:               "main",
+				DefaultUnauthorizedUserMode: syngit.UseDefaultUser,
+				ExcludedFields:              []string{".metadata.uid"},
+				DefaultRemoteUserRef: &corev1.ObjectReference{
+					Name:      remoteUserChopperName,
+					Namespace: namespace,
+				},
+				ProcessMode:      syngit.CommitApply,
+				PushMode:         syngit.SameBranch,
+				RemoteRepository: repoUrl,
+				ScopedResources: syngit.ScopedResources{
+					Rules: []admissionv1.RuleWithOperations{{
+						Operations: []admissionv1.OperationType{
+							admissionv1.Create,
+						},
+						Rule: admissionv1.Rule{
+							APIGroups:   []string{""},
+							APIVersions: []string{"v1"},
+							Resources:   []string{"configmaps"},
+						},
+					},
+					},
+				},
+			},
+		}
+		Eventually(func() bool {
+			err := sClient.As(Sanji).CreateOrUpdate(remotesyncer)
+			return err == nil
+		}, timeout, interval).Should(BeTrue())
+
+		Wait5()
+		By("creating a test configmap that fails (Chopper does not have access to green)")
+		cm := &corev1.ConfigMap{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "ConfigMap",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{Name: cmName, Namespace: namespace},
+			Data:       map[string]string{"test": "oui"},
+		}
+		_, err = sClient.KAs(Sanji).CoreV1().ConfigMaps(namespace).Create(ctx,
+			cm,
+			metav1.CreateOptions{},
+		)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("User permission denied for writing."))
+
+		By("updating the RemoteSyncer to use Luffy instead of Chopper")
+		remotesyncer.Spec.DefaultRemoteUserRef.Name = remoteUserLuffyName
+		Eventually(func() bool {
+			err := sClient.As(Sanji).CreateOrUpdate(remotesyncer)
+			return err == nil
+		}, timeout, interval).Should(BeTrue())
+
+		Wait5()
+		By("creating a test configmap that succeed (pushed as Luffy)")
+		_, err = sClient.KAs(Sanji).CoreV1().ConfigMaps(namespace).Create(ctx,
+			cm,
+			metav1.CreateOptions{},
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("checking if the configmap is present on the repo")
+		repo := &Repo{
+			Fqdn:  GitP1Fqdn,
+			Owner: "syngituser",
+			Name:  "green",
+		}
+		exists, err := IsObjectInRepo(*repo, cm)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(exists).To(BeTrue())
+
+		By("checking that the configmap is present on the cluster")
+		nnCm := types.NamespacedName{
+			Name:      cmName,
+			Namespace: namespace,
+		}
+		getCm := &corev1.ConfigMap{}
+
+		Eventually(func() bool {
+			err := sClient.As(Luffy).Get(nnCm, getCm)
+			return err == nil
+		}, timeout, interval).Should(BeTrue())
+
+		By("deleting the configmap from the cluster")
+		Eventually(func() bool {
+			err := sClient.As(Luffy).Delete(getCm)
+			return err == nil
+		}, timeout, interval).Should(BeTrue())
+
+		By("deleting the remote syncer from the cluster")
+		Eventually(func() bool {
+			err := sClient.As(Luffy).Delete(remotesyncer)
+			return err == nil
+		}, timeout, interval).Should(BeTrue())
+	})
+})

--- a/test/e2e/syngit/06_objects_lifecycle_test.go
+++ b/test/e2e/syngit/06_objects_lifecycle_test.go
@@ -1,0 +1,247 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e_syngit
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	admissionv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	syngit "syngit.io/syngit/api/v1beta2"
+	. "syngit.io/syngit/test/utils"
+)
+
+var _ = Describe("06 Test objects lifecycle", func() {
+
+	const (
+		remoteUserLuffyName               = "remoteuser-luffy"
+		remoteUserLuffyJupyterName        = "remoteuser-luffy"
+		remoteUserLuffySaturnName         = "remoteuser-luffy-saturn"
+		remotesyncerValidationWebhookName = "remotesyncer.syngit.io"
+		remoteSyncerName                  = "remotesyncer-test6"
+	)
+
+	It("should properly manage the RemoteUserBinding associated webhooks", func() {
+		By("adding syngit to scheme")
+		err := syngit.AddToScheme(scheme.Scheme)
+		Expect(err).NotTo(HaveOccurred())
+
+		luffySecretName := string(Luffy) + "-creds"
+
+		By("creating the RemoteUser & RemoteUserBinding for Luffy (jupyter)")
+		remoteUserLuffyJupyter := &syngit.RemoteUser{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      remoteUserLuffyJupyterName,
+				Namespace: namespace,
+				Annotations: map[string]string{
+					"syngit.syngit.io/associated-remote-userbinding": "true",
+				},
+			},
+			Spec: syngit.RemoteUserSpec{
+				Email:             "sample@email.com",
+				GitBaseDomainFQDN: GitP1Fqdn,
+				SecretRef: corev1.SecretReference{
+					Name: luffySecretName,
+				},
+			},
+		}
+		Eventually(func() bool {
+			err := sClient.As(Luffy).CreateOrUpdate(remoteUserLuffyJupyter)
+			return err == nil
+		}, timeout, interval).Should(BeTrue())
+
+		By("creating the RemoteUser & RemoteUserBinding for Luffy (saturn)")
+		remoteUserLuffySaturn := &syngit.RemoteUser{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      remoteUserLuffySaturnName,
+				Namespace: namespace,
+				Annotations: map[string]string{
+					"syngit.syngit.io/associated-remote-userbinding": "true",
+				},
+			},
+			Spec: syngit.RemoteUserSpec{
+				Email:             "sample@email.com",
+				GitBaseDomainFQDN: GitP2Fqdn,
+				SecretRef: corev1.SecretReference{
+					Name: luffySecretName,
+				},
+			},
+		}
+		Eventually(func() bool {
+			err := sClient.As(Luffy).CreateOrUpdate(remoteUserLuffySaturn)
+			return err == nil
+		}, timeout, interval).Should(BeTrue())
+
+		Wait10()
+		By("checking that the RemoteUserBinding refers to 2 RemoteUsers")
+		nnRub := types.NamespacedName{
+			Name:      fmt.Sprintf("%s%s", syngit.RubPrefix, string(Luffy)),
+			Namespace: namespace,
+		}
+		getRub := &syngit.RemoteUserBinding{}
+
+		Eventually(func() bool {
+			err := sClient.As(Luffy).Get(nnRub, getRub)
+			return err == nil
+		}, timeout, interval).Should(BeTrue())
+
+		Expect(len(getRub.Spec.RemoteRefs)).To(Equal(2))
+
+		By("deleting the saturn RemoteUser")
+		Eventually(func() bool {
+			err := sClient.As(Luffy).Delete(remoteUserLuffySaturn)
+			return err == nil
+		}, timeout, interval).Should(BeTrue())
+
+		Wait5()
+		By("checking that RemoteUserBinding now refers to only one RemoteUser")
+		Eventually(func() bool {
+			err := sClient.As(Luffy).Get(nnRub, getRub)
+			return err == nil
+		}, timeout, interval).Should(BeTrue())
+
+		Expect(len(getRub.Spec.RemoteRefs)).To(Equal(1))
+
+		By("deleting the jupyter RemoteUser")
+		Eventually(func() bool {
+			err := sClient.As(Luffy).Delete(remoteUserLuffyJupyter)
+			return err == nil
+		}, timeout, interval).Should(BeTrue())
+
+		Wait10()
+		By("checking that RemoteUserBinding does not exists")
+		err = sClient.As(Luffy).Get(nnRub, getRub)
+
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("not found"))
+	})
+
+	It("should properly manage the RemoteSyncer associated webhooks", func() {
+		By("adding syngit to scheme")
+		err := syngit.AddToScheme(scheme.Scheme)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("creating the RemoteUser & RemoteUserBinding for Luffy")
+		luffySecretName := string(Luffy) + "-creds"
+		remoteUserLuffy := &syngit.RemoteUser{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      remoteUserLuffyName,
+				Namespace: namespace,
+				Annotations: map[string]string{
+					"syngit.syngit.io/associated-remote-userbinding": "true",
+				},
+			},
+			Spec: syngit.RemoteUserSpec{
+				Email:             "sample@email.com",
+				GitBaseDomainFQDN: GitP1Fqdn,
+				SecretRef: corev1.SecretReference{
+					Name: luffySecretName,
+				},
+			},
+		}
+		Eventually(func() bool {
+			err := sClient.As(Luffy).CreateOrUpdate(remoteUserLuffy)
+			return err == nil
+		}, timeout, interval).Should(BeTrue())
+
+		Wait5()
+		repoUrl := "http://" + GitP1Fqdn + "/syngituser/blue.git"
+		By("creating the RemoteSyncer")
+		remotesyncer := &syngit.RemoteSyncer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      remoteSyncerName,
+				Namespace: namespace,
+			},
+			Spec: syngit.RemoteSyncerSpec{
+				DefaultBranch:               "main",
+				DefaultUnauthorizedUserMode: syngit.Block,
+				ExcludedFields:              []string{".metadata.uid"},
+				ProcessMode:                 syngit.CommitApply,
+				PushMode:                    syngit.SameBranch,
+				RemoteRepository:            repoUrl,
+				ScopedResources: syngit.ScopedResources{
+					Rules: []admissionv1.RuleWithOperations{{
+						Operations: []admissionv1.OperationType{
+							admissionv1.Create,
+						},
+						Rule: admissionv1.Rule{
+							APIGroups:   []string{"apps"},
+							APIVersions: []string{"v1"},
+							Resources:   []string{"statefulsets"},
+						},
+					},
+					},
+				},
+			},
+		}
+		Eventually(func() bool {
+			err := sClient.As(Luffy).CreateOrUpdate(remotesyncer)
+			return err == nil
+		}, timeout, interval).Should(BeTrue())
+
+		Wait5()
+		By("checking that the ValidationWebhhok scopes sts")
+		nnValidation := types.NamespacedName{
+			Name: remotesyncerValidationWebhookName,
+		}
+		getValidation := &admissionv1.ValidatingWebhookConfiguration{}
+
+		Eventually(func() bool {
+			err := sClient.As(Luffy).Get(nnValidation, getValidation)
+			return err == nil
+		}, timeout, interval).Should(BeTrue())
+
+		validations := getValidation.Webhooks
+		stsNb := 0
+		for _, validation := range validations {
+			rule := validation.Rules[0]
+			if rule.Resources[0] == remotesyncer.Spec.ScopedResources.Rules[0].Resources[0] {
+				stsNb += 1
+			}
+		}
+		Expect(stsNb).To(Equal(1))
+
+		By("deleting the remote syncer from the cluster")
+		Eventually(func() bool {
+			err := sClient.As(Luffy).Delete(remotesyncer)
+			return err == nil
+		}, timeout, interval).Should(BeTrue())
+
+		// Wait5()
+		// By("checking that the webhook does not intercept anything")
+		// Eventually(func() bool {
+		// 	err := sClient.As(Luffy).Get(nnValidation, getValidation)
+		// 	return err == nil
+		// }, timeout, interval).Should(BeTrue())
+
+		// validations = getValidation.Webhooks
+		// stsNb = 0
+		// for _, validation := range validations {
+		// 	rule := validation.Rules[0]
+		// 	if rule.Resources[0] == remotesyncer.Spec.ScopedResources.Rules[0].Resources[0] {
+		// 		stsNb += 1
+		// 	}
+		// }
+		// Expect(stsNb).To(Equal(0))
+		// Expect(len(validations)).To(Equal(0))
+	})
+})

--- a/test/e2e/syngit/07_bypass_subject_test.go
+++ b/test/e2e/syngit/07_bypass_subject_test.go
@@ -1,0 +1,288 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e_syngit
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	admissionv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	syngit "syngit.io/syngit/api/v1beta2"
+	. "syngit.io/syngit/test/utils"
+)
+
+var _ = Describe("07 Subject bypasses interception", func() {
+
+	const (
+		remoteUserLuffyName = "remoteuser-luffy"
+		remoteSyncer1Name   = "remotesyncer-test7.1"
+		remoteSyncer2Name   = "remotesyncer-test7.2"
+		cmName              = "test-cm7"
+	)
+
+	It("should apply the resource on the cluster but not push it on the git repository (CommitApply)", func() {
+
+		ctx := context.TODO()
+
+		By("adding syngit to scheme")
+		err := syngit.AddToScheme(scheme.Scheme)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("creating the RemoteUser & RemoteUserBinding for Luffy")
+		luffySecretName := string(Luffy) + "-creds"
+		remoteUserLuffy := &syngit.RemoteUser{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      remoteUserLuffyName,
+				Namespace: namespace,
+				Annotations: map[string]string{
+					"syngit.syngit.io/associated-remote-userbinding": "true",
+				},
+			},
+			Spec: syngit.RemoteUserSpec{
+				Email:             "sample@email.com",
+				GitBaseDomainFQDN: GitP1Fqdn,
+				SecretRef: corev1.SecretReference{
+					Name: luffySecretName,
+				},
+			},
+		}
+		Eventually(func() bool {
+			err := sClient.As(Luffy).CreateOrUpdate(remoteUserLuffy)
+			return err == nil
+		}, timeout, interval).Should(BeTrue())
+
+		Wait5()
+		repoUrl := "http://" + GitP1Fqdn + "/syngituser/blue.git"
+		By("creating the RemoteSyncer")
+		remotesyncer := &syngit.RemoteSyncer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      remoteSyncer1Name,
+				Namespace: namespace,
+			},
+			Spec: syngit.RemoteSyncerSpec{
+				DefaultBranch:               "main",
+				DefaultUnauthorizedUserMode: syngit.Block,
+				BypassInterceptionSubjects: []v1.Subject{{
+					APIGroup: "rbac.authorization.k8s.io",
+					Kind:     "User",
+					Name:     string(Luffy),
+				}},
+				ExcludedFields:   []string{".metadata.uid"},
+				ProcessMode:      syngit.CommitApply,
+				PushMode:         syngit.SameBranch,
+				RemoteRepository: repoUrl,
+				ScopedResources: syngit.ScopedResources{
+					Rules: []admissionv1.RuleWithOperations{{
+						Operations: []admissionv1.OperationType{
+							admissionv1.Create,
+						},
+						Rule: admissionv1.Rule{
+							APIGroups:   []string{""},
+							APIVersions: []string{"v1"},
+							Resources:   []string{"configmaps"},
+						},
+					},
+					},
+				},
+			},
+		}
+		Eventually(func() bool {
+			err := sClient.As(Luffy).CreateOrUpdate(remotesyncer)
+			return err == nil
+		}, timeout, interval).Should(BeTrue())
+
+		Wait5()
+		By("creating a test configmap")
+		cm := &corev1.ConfigMap{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "ConfigMap",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{Name: cmName, Namespace: namespace},
+			Data:       map[string]string{"test": "oui"},
+		}
+		_, err = sClient.KAs(Luffy).CoreV1().ConfigMaps(namespace).Create(ctx,
+			cm,
+			metav1.CreateOptions{},
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("checking that the configmap is not present on the repo")
+		repo := &Repo{
+			Fqdn:  GitP1Fqdn,
+			Owner: "syngituser",
+			Name:  "blue",
+		}
+		exists, err := IsObjectInRepo(*repo, cm)
+		Expect(err).To(HaveOccurred())
+		Expect(exists).To(BeFalse())
+
+		By("checking that the configmap is present on the cluster")
+		nnCm := types.NamespacedName{
+			Name:      cmName,
+			Namespace: namespace,
+		}
+		getCm := &corev1.ConfigMap{}
+
+		Eventually(func() bool {
+			err := sClient.As(Luffy).Get(nnCm, getCm)
+			return err == nil
+		}, timeout, interval).Should(BeTrue())
+
+		By("deleting the configmap from the cluster")
+		Eventually(func() bool {
+			err := sClient.As(Luffy).Delete(getCm)
+			return err == nil
+		}, timeout, interval).Should(BeTrue())
+
+		By("deleting the remote syncer from the cluster")
+		Eventually(func() bool {
+			err := sClient.As(Luffy).Delete(remotesyncer)
+			return err == nil
+		}, timeout, interval).Should(BeTrue())
+
+	})
+
+	It("should apply the resource on the cluster but not push it on the git repository (CommitOnly)", func() {
+
+		ctx := context.TODO()
+
+		By("adding syngit to scheme")
+		err := syngit.AddToScheme(scheme.Scheme)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("creating the RemoteUser & RemoteUserBinding for Luffy")
+		luffySecretName := string(Luffy) + "-creds"
+		remoteUserLuffy := &syngit.RemoteUser{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      remoteUserLuffyName,
+				Namespace: namespace,
+				Annotations: map[string]string{
+					"syngit.syngit.io/associated-remote-userbinding": "true",
+				},
+			},
+			Spec: syngit.RemoteUserSpec{
+				Email:             "sample@email.com",
+				GitBaseDomainFQDN: GitP1Fqdn,
+				SecretRef: corev1.SecretReference{
+					Name: luffySecretName,
+				},
+			},
+		}
+		Eventually(func() bool {
+			err := sClient.As(Luffy).CreateOrUpdate(remoteUserLuffy)
+			return err == nil
+		}, timeout, interval).Should(BeTrue())
+
+		Wait5()
+		repoUrl := "http://" + GitP1Fqdn + "/syngituser/blue.git"
+		By("creating the RemoteSyncer")
+		remotesyncer := &syngit.RemoteSyncer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      remoteSyncer2Name,
+				Namespace: namespace,
+			},
+			Spec: syngit.RemoteSyncerSpec{
+				DefaultBranch:               "main",
+				DefaultUnauthorizedUserMode: syngit.Block,
+				BypassInterceptionSubjects: []v1.Subject{{
+					APIGroup: "rbac.authorization.k8s.io",
+					Kind:     "User",
+					Name:     string(Luffy),
+				}},
+				ExcludedFields:   []string{".metadata.uid"},
+				ProcessMode:      syngit.CommitOnly,
+				PushMode:         syngit.SameBranch,
+				RemoteRepository: repoUrl,
+				ScopedResources: syngit.ScopedResources{
+					Rules: []admissionv1.RuleWithOperations{{
+						Operations: []admissionv1.OperationType{
+							admissionv1.Create,
+						},
+						Rule: admissionv1.Rule{
+							APIGroups:   []string{""},
+							APIVersions: []string{"v1"},
+							Resources:   []string{"configmaps"},
+						},
+					},
+					},
+				},
+			},
+		}
+		Eventually(func() bool {
+			err := sClient.As(Luffy).CreateOrUpdate(remotesyncer)
+			return err == nil
+		}, timeout, interval).Should(BeTrue())
+
+		Wait5()
+		By("creating a test configmap")
+		cm := &corev1.ConfigMap{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "ConfigMap",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{Name: cmName, Namespace: namespace},
+			Data:       map[string]string{"test": "oui"},
+		}
+		_, err = sClient.KAs(Luffy).CoreV1().ConfigMaps(namespace).Create(ctx,
+			cm,
+			metav1.CreateOptions{},
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("checking that the configmap is not present on the repo")
+		repo := &Repo{
+			Fqdn:  GitP1Fqdn,
+			Owner: "syngituser",
+			Name:  "blue",
+		}
+		exists, err := IsObjectInRepo(*repo, cm)
+		Expect(err).To(HaveOccurred())
+		Expect(exists).To(BeFalse())
+
+		By("checking that the configmap is present on the cluster")
+		nnCm := types.NamespacedName{
+			Name:      cmName,
+			Namespace: namespace,
+		}
+		getCm := &corev1.ConfigMap{}
+
+		Eventually(func() bool {
+			err := sClient.As(Luffy).Get(nnCm, getCm)
+			return err == nil
+		}, timeout, interval).Should(BeTrue())
+
+		By("deleting the configmap from the cluster")
+		Eventually(func() bool {
+			err := sClient.As(Luffy).Delete(getCm)
+			return err == nil
+		}, timeout, interval).Should(BeTrue())
+
+		By("deleting the remote syncer from the cluster")
+		Eventually(func() bool {
+			err := sClient.As(Luffy).Delete(remotesyncer)
+			return err == nil
+		}, timeout, interval).Should(BeTrue())
+
+	})
+})

--- a/test/utils/.env
+++ b/test/utils/.env
@@ -5,7 +5,7 @@ ADMIN_USERNAME="syngituser"                       # Admin username
 ADMIN_PASSWORD="syngit_password"                  # Admin password
 ADMIN_EMAIL="syngit@example.com"                  # Admin email
 
-NO_RIGHT_USERNAME="no-right-user"
+SANJI_USERNAME="sanji"
 CHOPPER_USERNAME="chopper-jb"
 LUFFY_USERNAME="luffy-jbg-sb"
 

--- a/test/utils/custom-client.go
+++ b/test/utils/custom-client.go
@@ -1,0 +1,42 @@
+package utils
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type CustomClient struct {
+	ctx    context.Context
+	client client.Client
+}
+
+func (customClient CustomClient) CreateOrUpdate(obj client.Object) error {
+	// Create a deep copy of the object to avoid modifying the input
+	existingObj := obj.DeepCopyObject().(client.Object)
+
+	// Check if the object exists
+	err := customClient.client.Get(customClient.ctx, client.ObjectKeyFromObject(obj), existingObj)
+	if errors.IsNotFound(err) {
+		// Object doesn't exist, create it
+		return customClient.client.Create(customClient.ctx, obj)
+	} else if err != nil {
+		// Return other errors from GET
+		return err
+	}
+
+	// Retain the resource version to update the object correctly
+	obj.SetResourceVersion(existingObj.GetResourceVersion())
+
+	return customClient.client.Update(customClient.ctx, obj)
+}
+
+func (customClient CustomClient) Get(namespacedName types.NamespacedName, obj client.Object) error {
+	return customClient.client.Get(customClient.ctx, namespacedName, obj)
+}
+
+func (customClient CustomClient) Delete(obj client.Object) error {
+	return customClient.client.Delete(customClient.ctx, obj)
+}

--- a/test/utils/gitea/setup-gitea-users.sh
+++ b/test/utils/gitea/setup-gitea-users.sh
@@ -9,21 +9,21 @@ NO_RIGHT_PWD="no-right-user-pwd"
 
 POD_NAME=$(kubectl get pods -n $NS_JUPYTER -l app.kubernetes.io/name=gitea -o jsonpath="{.items[0].metadata.name}")
 kubectl exec -i $POD_NAME -n $NS_JUPYTER -- gitea admin user create \
-  --username $NO_RIGHT_USERNAME \
+  --username $SANJI_USERNAME \
   --password "1$NO_RIGHT_PWD" \
-  --email "$NO_RIGHT_USERNAME@syngit.io" 2>&1 > /dev/null
+  --email "$SANJI_USERNAME@syngit.io" 2>&1 > /dev/null
 kubectl exec -i $POD_NAME -n $NS_JUPYTER -- gitea admin user change-password \
-  --username $NO_RIGHT_USERNAME \
+  --username $SANJI_USERNAME \
   --password $NO_RIGHT_PWD \
   --must-change-password=false 2>&1 > /dev/null
 
 POD_NAME=$(kubectl get pods -n $NS_SATURN -l app.kubernetes.io/name=gitea -o jsonpath="{.items[0].metadata.name}")
 kubectl exec -i $POD_NAME -n $NS_SATURN -- gitea admin user create \
-  --username $NO_RIGHT_USERNAME \
+  --username $SANJI_USERNAME \
   --password "1$NO_RIGHT_PWD" \
-  --email "$NO_RIGHT_USERNAME@syngit.io" 2>&1 > /dev/null
+  --email "$SANJI_USERNAME@syngit.io" 2>&1 > /dev/null
 kubectl exec -i $POD_NAME -n $NS_SATURN -- gitea admin user change-password \
-  --username $NO_RIGHT_USERNAME \
+  --username $SANJI_USERNAME \
   --password $NO_RIGHT_PWD \
   --must-change-password=false 2>&1 > /dev/null
 

--- a/test/utils/mock-users.go
+++ b/test/utils/mock-users.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -16,7 +17,7 @@ type TestUser string
 
 var (
 	Admin   TestUser
-	NoRight TestUser
+	Sanji   TestUser
 	Chopper TestUser
 	Luffy   TestUser
 )
@@ -45,18 +46,27 @@ func (tu *SyngitTestUsersClientset) KAs(username TestUser) *Clientset {
 	}
 }
 
-func (tu *SyngitTestUsersClientset) As(username TestUser) client.Client {
+func (tu *SyngitTestUsersClientset) CAs(username TestUser) client.Client {
 	client, _ := tu.impersonate(username)
 	return client
 }
 
+func (tu *SyngitTestUsersClientset) As(username TestUser) CustomClient {
+	client, _ := tu.impersonate(username)
+	customClient := CustomClient{
+		ctx:    context.TODO(),
+		client: client,
+	}
+	return customClient
+}
+
 func (tu *SyngitTestUsersClientset) Initialize() error {
 	Admin = TestUser(os.Getenv("ADMIN_USERNAME"))
-	NoRight = TestUser(os.Getenv("NO_RIGHT_USERNAME"))
+	Sanji = TestUser(os.Getenv("SANJI_USERNAME"))
 	Chopper = TestUser(os.Getenv("CHOPPER_USERNAME"))
 	Luffy = TestUser(os.Getenv("LUFFY_USERNAME"))
 
-	Users = []TestUser{NoRight, Chopper, Luffy}
+	Users = []TestUser{Sanji, Chopper, Luffy}
 
 	kubeconfig := os.Getenv("KUBECONFIG")
 	if kubeconfig == "" {

--- a/test/utils/syngit.go
+++ b/test/utils/syngit.go
@@ -1,20 +1,53 @@
 package utils
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
 
-	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"gopkg.in/yaml.v2"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-func getObjectMetadata(obj runtime.Object) (metav1.Object, error) {
-	// Use meta.Accessor to get the metadata
-	metadata, err := meta.Accessor(obj)
+func GetGiteaURL(namespace string) (string, error) {
+	// Run kubectl to get the NodePort of the gitea service in the given namespace
+	port, err := exec.Command("kubectl", "get", "svc", "gitea-http", "-n", namespace, "-o", "jsonpath={.spec.ports[0].nodePort}").Output()
 	if err != nil {
-		return nil, fmt.Errorf("failed to access metadata: %w", err)
+		return "", err
 	}
-	return metadata, nil
+	ip, err := exec.Command("kubectl", "get", "node", "-o", "jsonpath={.items[0].status.addresses[0].address}").Output()
+	if err != nil {
+		return "", err
+	}
+
+	url := fmt.Sprintf("%s:%s", ip, port)
+	return url, nil
+}
+
+func RetrieveRepos() {
+	Repos[os.Getenv("PLATFORM1")+"-"+os.Getenv("REPO1")] = Repo{
+		Fqdn:  GitP1Fqdn,
+		Owner: os.Getenv("ADMIN_USERNAME"),
+		Name:  os.Getenv("REPO1"),
+	}
+	Repos[os.Getenv("PLATFORM1")+"-"+os.Getenv("REPO2")] = Repo{
+		Fqdn:  GitP1Fqdn,
+		Owner: os.Getenv("ADMIN_USERNAME"),
+		Name:  os.Getenv("REPO2"),
+	}
+	Repos[os.Getenv("PLATFORM2")+"-"+os.Getenv("REPO1")] = Repo{
+		Fqdn:  GitP2Fqdn,
+		Owner: os.Getenv("ADMIN_USERNAME"),
+		Name:  os.Getenv("REPO1"),
+	}
+	Repos[os.Getenv("PLATFORM2")+"-"+os.Getenv("REPO2")] = Repo{
+		Fqdn:  GitP2Fqdn,
+		Owner: os.Getenv("ADMIN_USERNAME"),
+		Name:  os.Getenv("REPO2"),
+	}
 }
 
 func AreObjectsUploaded(repo Repo, objects []runtime.Object) bool {
@@ -25,4 +58,90 @@ func AreObjectsUploaded(repo Repo, objects []runtime.Object) bool {
 		}
 	}
 	return true
+}
+
+func GetObjectInRepo(repo Repo, tree []Tree, obj runtime.Object) (*File, error) {
+	return searchForObjectInAllManifests(repo, tree, obj)
+}
+
+func IsObjectInRepo(repo Repo, obj runtime.Object) (bool, error) {
+	tree, err := GetRepoTree(repo)
+	if err != nil {
+		return false, err
+	}
+	file, err := searchForObjectInAllManifests(repo, tree, obj)
+	return (file != nil), err
+}
+
+func IsFieldDefined(repo Repo, obj runtime.Object, yamlPath string) (bool, error) {
+	tree, err := GetRepoTree(repo)
+	if err != nil {
+		return false, err
+	}
+	file, err := searchForObjectInAllManifests(repo, tree, obj)
+	if err != nil {
+		return false, err
+	}
+
+	var parsed map[interface{}]interface{}
+	err = yaml.Unmarshal(file.Content, &parsed)
+	if err != nil {
+		return false, err
+	}
+
+	_, found := isFieldDefinedInYaml(parsed, yamlPath)
+
+	return found, nil
+}
+
+// GetLatestCommit fetches metadata of the latest commit from the specified repository.
+func GetLatestCommit(repoUrl string, repoOwner string, repoName string) (*Commit, error) {
+	url := fmt.Sprintf("%s/api/v1/repos/%s/%s/commits?limit=1", repoUrl, repoOwner, repoName)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create HTTP request: %w", err)
+	}
+
+	// Add basic auth header
+	token, err := getAdminToken(repoUrl)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Authorization", "token "+token)
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to get latest commit: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to get latest commit: %s", resp.Status)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %v", err)
+	}
+
+	var commits []Commit
+	if err := json.Unmarshal(body, &commits); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response: %v", err)
+	}
+
+	if len(commits) == 0 {
+		return nil, fmt.Errorf("no commits found in the repository")
+	}
+
+	return &commits[0], nil
+}
+
+func GetRepoTree(repo Repo) ([]Tree, error) {
+	return getTree(repo.Fqdn, repo.Owner, repo.Name, "main")
 }

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -171,7 +171,6 @@ func GetProjectDir() (string, error) {
 	if err != nil {
 		return wd, err
 	}
-	fmt.Println(wd)
 	wd = strings.Split(wd, "/test/e2e")[0]
 	return wd, nil
 }


### PR DESCRIPTION
e2e tests:
- Test `RemoteUser` & `RemoteUserBinding` dependency
- Test `RemoteSyncer` & `ValidationWebhook` dependency
- Test `CommitOnly` & `CommitApply` mode
- Test `excludedFields`
- Test default `RemoteUser` when `RemoteUserBinding` does not exist
- Test bypass interception subject

Fix the automatically created `RemoteUserBinding` was not deleting itself when it has 0 `RemoteUser` associated