### PR TITLE
:sparkles: Add shortnames for CRDs

### DIFF
--- a/charts/0.1.1/templates/crd/syngit.syngit.io_remotesyncer.yaml
+++ b/charts/0.1.1/templates/crd/syngit.syngit.io_remotesyncer.yaml
@@ -20,12 +20,18 @@ spec:
           path: /convert
           port: 443
       conversionReviewVersions:
-      - v1
+      - v1beta2
+      - v1beta1
   group: syngit.syngit.io
   names:
+    categories:
+    - syngit
     kind: RemoteSyncer
     listKind: RemoteSyncerList
     plural: remotesyncers
+    shortNames:
+    - rs
+    - rss
     singular: remotesyncer
   scope: Namespaced
   versions:

--- a/charts/0.1.1/templates/crd/syngit.syngit.io_remoteuser.yaml
+++ b/charts/0.1.1/templates/crd/syngit.syngit.io_remoteuser.yaml
@@ -20,12 +20,18 @@ spec:
           path: /convert
           port: 443
       conversionReviewVersions:
-      - v1
+      - v1beta2
+      - v1beta1
   group: syngit.syngit.io
   names:
+    categories:
+    - syngit
     kind: RemoteUser
     listKind: RemoteUserList
     plural: remoteusers
+    shortNames:
+    - ru
+    - rus
     singular: remoteuser
   scope: Namespaced
   versions:

--- a/charts/0.1.1/templates/crd/syngit.syngit.io_remoteuserbinding.yaml
+++ b/charts/0.1.1/templates/crd/syngit.syngit.io_remoteuserbinding.yaml
@@ -20,12 +20,18 @@ spec:
           path: /convert
           port: 443
       conversionReviewVersions:
-      - v1
+      - v1beta2
+      - v1beta1
   group: syngit.syngit.io
   names:
+    categories:
+    - syngit
     kind: RemoteUserBinding
     listKind: RemoteUserBindingList
     plural: remoteuserbindings
+    shortNames:
+    - rub
+    - rubs
     singular: remoteuserbinding
   scope: Namespaced
   versions:

--- a/test/e2e/syngit/03_commitapply_cm_test.go
+++ b/test/e2e/syngit/03_commitapply_cm_test.go
@@ -102,7 +102,7 @@ var _ = Describe("03 CommitApply a ConfigMap", func() {
 			return err == nil
 		}, timeout, interval).Should(BeTrue())
 
-		Wait5()
+		Wait10()
 		By("creating a test configmap")
 		cm := &corev1.ConfigMap{
 			TypeMeta: metav1.TypeMeta{

--- a/test/utils/custom-client.go
+++ b/test/utils/custom-client.go
@@ -38,5 +38,14 @@ func (customClient CustomClient) Get(namespacedName types.NamespacedName, obj cl
 }
 
 func (customClient CustomClient) Delete(obj client.Object) error {
-	return customClient.client.Delete(customClient.ctx, obj)
+	// Create a deep copy of the object to avoid modifying the input
+	existingObj := obj.DeepCopyObject().(client.Object)
+
+	// Check if the object exists
+	err := customClient.client.Get(customClient.ctx, client.ObjectKeyFromObject(obj), existingObj)
+	if err == nil {
+		return customClient.client.Delete(customClient.ctx, obj)
+	}
+
+	return nil
 }


### PR DESCRIPTION
Add
- For `RemoteUser`: `ru` & `rus`
- For `RemoteUserBinding`: `rub` & `rubs`
- For `RemoteSyncer`: `rs` & `rss`