### PR TITLE
:sparkles: RemoteSyncer webhook RBAC checker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ cleanup-gitea:
 ##@ Development
 
 WEBHOOK_PATH ?= config/webhook
-IMAGE ?= local.cluster/syngit-controller:dev
+IMAGE ?= local/syngit-controller:dev
 .PHONY: dev-deploy
 dev-deploy: # Launch dev env on the cluster
 	kind create cluster --name $(DEV_CLUSTER) 2>/dev/null || true
@@ -72,10 +72,9 @@ LATEST_CHART ?= $(shell find charts -mindepth 1 -maxdepth 1 -type d -exec basena
 .PHONY: chart-install
 chart-install:
 	helm install syngit charts/$(LATEST_CHART) -n syngit --create-namespace \
-		--set controller.image.prefix=local.cluster \
+		--set controller.image.prefix=local \
 		--set controller.image.name=syngit-controller \
-		--set controller.image.tag=dev \
-		--set controller.image.imagePullPolicy=IfNotPresent
+		--set controller.image.tag=dev
 
 .PHONY: chart-uninstall
 chart-uninstall:

--- a/api/v1beta2/remoteuser_conversion.go
+++ b/api/v1beta2/remoteuser_conversion.go
@@ -45,9 +45,10 @@ func (src *RemoteUser) ConvertTo(dstRaw conversion.Hub) error {
 
 	associatedRemoteUserBinding, err := strconv.ParseBool(src.Annotations["syngit.syngit.io/associated-remote-userbinding"])
 	if err != nil {
-		return err
+		dst.Spec.AssociatedRemoteUserBinding = false
+	} else {
+		dst.Spec.AssociatedRemoteUserBinding = associatedRemoteUserBinding
 	}
-	dst.Spec.AssociatedRemoteUserBinding = associatedRemoteUserBinding
 
 	return nil
 }

--- a/charts/0.2.0/Chart.yaml
+++ b/charts/0.2.0/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: syngit
+description: An operator to push resources onto git
+type: application
+version: 0.2.0
+appVersion: 0.2.0
+home: https://github.com/syngit-org/syngit
+icon: https://raw.githubusercontent.com/syngit-org/syngit/main/img/icon.png
+maintainers:
+  - email: dassieu.damien@gmail.com
+    name: Damien

--- a/charts/0.2.0/templates/certmanager/certificate.yaml
+++ b/charts/0.2.0/templates/certmanager/certificate.yaml
@@ -1,0 +1,36 @@
+{{- if eq .Values.webhook.certmanager.enable true }}
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    app.kubernetes.io/name: certificate
+    app.kubernetes.io/instance: serving-cert
+    app.kubernetes.io/component: certificate
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  name: {{ .Release.Name }}-selfsigned-issuer
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app.kubernetes.io/name: certificate
+    app.kubernetes.io/instance: serving-cert
+    app.kubernetes.io/component: certificate
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  name: operator-webhook-cert
+spec:
+  dnsNames:
+  - webhook-crd-service.{{ .Release.Namespace }}.svc
+  - webhook-crd-service.{{ .Release.Namespace }}.svc.local
+  - syngit-remote-syncer-webhook-service.{{ .Release.Namespace }}.svc
+  - syngit-remote-syncer-webhook-service.{{ .Release.Namespace }}.svc.local
+  issuerRef:
+    kind: Issuer
+    name: {{ .Release.Name }}-selfsigned-issuer
+  secretName: {{ .Values.webhook.certmanager.certificate.secret }}
+{{- end }}

--- a/charts/0.2.0/templates/controller/auth_proxy_service.yaml
+++ b/charts/0.2.0/templates/controller/auth_proxy_service.yaml
@@ -1,0 +1,22 @@
+{{- if eq .Values.controller.rbacProxy.enable true }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    control-plane: controller-manager
+    app.kubernetes.io/name: service
+    app.kubernetes.io/instance: controller-manager-metrics-service
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  name: {{ .Release.Name }}-controller-manager-metrics-service
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: https
+  selector:
+    control-plane: controller-manager
+{{- end }}

--- a/charts/0.2.0/templates/controller/manager.yaml
+++ b/charts/0.2.0/templates/controller/manager.yaml
@@ -1,0 +1,99 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  labels:
+    control-plane: controller-manager
+    app.kubernetes.io/name: deployment
+    app.kubernetes.io/instance: controller-manager
+    app.kubernetes.io/component: manager
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+spec:
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        control-plane: controller-manager
+    spec:
+      {{- if .Values.controller.image.imagePullSecrets }}
+      imagePullSecrets:
+        {{ toYaml .Values.controller.image.imagePullSecrets | nindent 8 }}
+      {{- end }}
+      containers:
+      {{- if eq .Values.controller.metrics.enable true }}
+      - name: kube-rbac-proxy
+        securityContext: {{ toYaml .Values.controller.rbacProxy.securityContext | nindent 10 }}
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
+        args:
+        - "--secure-listen-address=0.0.0.0:8443"
+        - "--upstream={{ .Values.controller.rbacProxy.upstreamAddress }}"
+        - "--logtostderr=true"
+        - "--v=0"
+        ports:
+        - containerPort: 8443
+          protocol: TCP
+          name: https
+        resources: {{ toYaml .Values.controller.rbacProxy.resources | nindent 10 }}
+      {{- end }}
+      - command:
+        - /manager
+        {{- if .Values.controller.image.imagePullPolicy }}
+        imagePullPolicy: {{ .Values.controller.image.imagePullPolicy }}
+        {{- end }}
+        args:
+        - "--leader-elect"
+        {{- if eq .Values.controller.metrics.enable true }}
+        - "--health-probe-bind-address=:8081"
+        - "--metrics-bind-address={{ .Values.controller.metrics.bindAddress }}"
+        {{- end }}
+        image: {{ .Values.controller.image.prefix }}/{{ .Values.controller.image.name }}:{{ .Values.controller.image.tag }}
+        env:
+        - name: MANAGER_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: DYNAMIC_WEBHOOK_NAME
+          value: {{ .Values.controller.dynamicWebhookName }}
+        name: manager
+        securityContext: {{ toYaml .Values.controller.securityContext | nindent 10 }}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources: {{ toYaml .Values.controller.resources | nindent 10 }}
+        ports:
+        - containerPort: 9443
+          name: wbhk-crd-srv
+          protocol: TCP
+        - containerPort: 9444
+          name: wbhk-pusher-srv
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      serviceAccountName: {{ .Release.Name }}-controller-manager
+      terminationGracePeriodSeconds: 10
+      {{- if .Values.controller.tolerations }}
+      tolerations: {{ toYaml .Values.controller.tolerations | nindent 8 }}
+      {{- end }}
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: {{ .Values.webhook.certmanager.certificate.secret }}

--- a/charts/0.2.0/templates/crd/syngit.syngit.io_remotesyncer.yaml
+++ b/charts/0.2.0/templates/crd/syngit.syngit.io_remotesyncer.yaml
@@ -1,0 +1,1187 @@
+{{- if eq .Values.installCRD true }}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+    {{- if eq .Values.webhook.certmanager.enable true }}
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/operator-webhook-cert
+    {{- end }}
+  name: remotesyncers.syngit.syngit.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          namespace: {{ .Release.Namespace }}
+          name: webhook-crd-service
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1
+  group: syngit.syngit.io
+  names:
+    categories:
+    - syngit
+    kind: RemoteSyncer
+    listKind: RemoteSyncerList
+    plural: remotesyncers
+    shortNames:
+    - rs
+    - rss
+    singular: remotesyncer
+  scope: Namespaced
+  versions:
+  - deprecated: true
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: RemoteSyncer is the Schema for the remotesyncers API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: RemoteSyncerSpec defines the desired state of RemoteSyncer
+            properties:
+              bypassInterceptionSubjects:
+                items:
+                  description: |-
+                    Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,
+                    or a value for non-objects such as user and group names.
+                  properties:
+                    apiGroup:
+                      description: |-
+                        APIGroup holds the API group of the referenced subject.
+                        Defaults to "" for ServiceAccount subjects.
+                        Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                      type: string
+                    kind:
+                      description: |-
+                        Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount".
+                        If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                      type: string
+                    name:
+                      description: Name of the object being referenced.
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty
+                        the Authorizer should report an error.
+                      type: string
+                  required:
+                  - kind
+                  - name
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
+              caBundle:
+                description: |-
+                  SecretReference represents a Secret Reference. It has enough information to retrieve secret
+                  in any namespace
+                properties:
+                  name:
+                    description: name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              defaultBlockAppliedMessage:
+                type: string
+              defaultBranch:
+                type: string
+              defaultUnauthorizedUserMode:
+                type: string
+              defaultUser:
+                description: |-
+                  ObjectReference contains enough information to let you inspect or modify the referred object.
+                  ---
+                  New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.
+                   1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.
+                   2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular
+                      restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".
+                      Those cannot be well described when embedded.
+                   3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.
+                   4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity
+                      during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple
+                      and the version of the actual struct is irrelevant.
+                   5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type
+                      will affect numerous schemas.  Don't make new APIs embed an underspecified API type they do not control.
+
+
+                  Instead of using this type, create a locally provided and used type that is well-focused on your reference.
+                  For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                      TODO: this design is not final and this field is subject to change in the future.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              excludedFields:
+                items:
+                  type: string
+                type: array
+              excludedFieldsConfig:
+                description: |-
+                  ObjectReference contains enough information to let you inspect or modify the referred object.
+                  ---
+                  New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.
+                   1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.
+                   2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular
+                      restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".
+                      Those cannot be well described when embedded.
+                   3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.
+                   4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity
+                      during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple
+                      and the version of the actual struct is irrelevant.
+                   5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type
+                      will affect numerous schemas.  Don't make new APIs embed an underspecified API type they do not control.
+
+
+                  Instead of using this type, create a locally provided and used type that is well-focused on your reference.
+                  For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                      TODO: this design is not final and this field is subject to change in the future.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              insecureSkipTlsVerify:
+                type: boolean
+              processMode:
+                type: string
+              pushMode:
+                type: string
+              remoteRepository:
+                format: uri
+                type: string
+              rootPath:
+                type: string
+              scopedResources:
+                properties:
+                  matchPolicy:
+                    description: MatchPolicyType specifies the type of match policy.
+                    type: string
+                  objectSelector:
+                    description: |-
+                      A label selector is a label query over a set of resources. The result of matchLabels and
+                      matchExpressions are ANDed. An empty label selector matches all objects. A null
+                      label selector matches no objects.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced during a strategic
+                                merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  rules:
+                    items:
+                      description: |-
+                        RuleWithOperations is a tuple of Operations and Resources. It is recommended to make
+                        sure that all the tuple expansions are valid.
+                      properties:
+                        apiGroups:
+                          description: |-
+                            APIGroups is the API groups the resources belong to. '*' is all groups.
+                            If '*' is present, the length of the slice must be one.
+                            Required.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        apiVersions:
+                          description: |-
+                            APIVersions is the API versions the resources belong to. '*' is all versions.
+                            If '*' is present, the length of the slice must be one.
+                            Required.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        operations:
+                          description: |-
+                            Operations is the operations the admission hook cares about - CREATE, UPDATE, DELETE, CONNECT or *
+                            for all of those operations and any future admission operations that are added.
+                            If '*' is present, the length of the slice must be one.
+                            Required.
+                          items:
+                            description: OperationType specifies an operation for
+                              a request.
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        resources:
+                          description: |-
+                            Resources is a list of resources this rule applies to.
+
+
+                            For example:
+                            'pods' means pods.
+                            'pods/log' means the log subresource of pods.
+                            '*' means all resources, but not subresources.
+                            'pods/*' means all subresources of pods.
+                            '*/scale' means all scale subresources.
+                            '*/*' means all resources and their subresources.
+
+
+                            If wildcard is present, the validation rule will ensure resources do not
+                            overlap with each other.
+
+
+                            Depending on the enclosing object, subresources might not be allowed.
+                            Required.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        scope:
+                          description: |-
+                            scope specifies the scope of this rule.
+                            Valid values are "Cluster", "Namespaced", and "*"
+                            "Cluster" means that only cluster-scoped resources will match this rule.
+                            Namespace API objects are cluster-scoped.
+                            "Namespaced" means that only namespaced resources will match this rule.
+                            "*" means that there are no scope restrictions.
+                            Subresources match the scope of their parent resource.
+                            Default is "*".
+                          type: string
+                      type: object
+                    type: array
+                type: object
+            required:
+            - defaultUnauthorizedUserMode
+            - processMode
+            - pushMode
+            - remoteRepository
+            type: object
+          status:
+            properties:
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              lastBypassedObjectState:
+                properties:
+                  lastBypassObject:
+                    properties:
+                      group:
+                        type: string
+                      name:
+                        type: string
+                      resource:
+                        type: string
+                      version:
+                        type: string
+                    required:
+                    - group
+                    - name
+                    - resource
+                    - version
+                    type: object
+                  lastBypassObjectTime:
+                    format: date-time
+                    type: string
+                  lastBypassObjectUserInfo:
+                    description: |-
+                      UserInfo holds the information about the user needed to implement the
+                      user.Info interface.
+                    properties:
+                      extra:
+                        additionalProperties:
+                          description: ExtraValue masks the value so protobuf can
+                            generate
+                          items:
+                            type: string
+                          type: array
+                        description: Any additional information provided by the authenticator.
+                        type: object
+                      groups:
+                        description: The names of groups this user is a part of.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      uid:
+                        description: |-
+                          A unique value that identifies this user across time. If this user is
+                          deleted and another user by the same name is added, they will have
+                          different UIDs.
+                        type: string
+                      username:
+                        description: The name that uniquely identifies this user among
+                          all active users.
+                        type: string
+                    type: object
+                type: object
+              lastObservedObjectState:
+                properties:
+                  lastObservedObject:
+                    properties:
+                      group:
+                        type: string
+                      name:
+                        type: string
+                      resource:
+                        type: string
+                      version:
+                        type: string
+                    required:
+                    - group
+                    - name
+                    - resource
+                    - version
+                    type: object
+                  lastObservedObjectTime:
+                    format: date-time
+                    type: string
+                  lastObservedObjectUserInfo:
+                    description: |-
+                      UserInfo holds the information about the user needed to implement the
+                      user.Info interface.
+                    properties:
+                      extra:
+                        additionalProperties:
+                          description: ExtraValue masks the value so protobuf can
+                            generate
+                          items:
+                            type: string
+                          type: array
+                        description: Any additional information provided by the authenticator.
+                        type: object
+                      groups:
+                        description: The names of groups this user is a part of.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      uid:
+                        description: |-
+                          A unique value that identifies this user across time. If this user is
+                          deleted and another user by the same name is added, they will have
+                          different UIDs.
+                        type: string
+                      username:
+                        description: The name that uniquely identifies this user among
+                          all active users.
+                        type: string
+                    type: object
+                type: object
+              lastPushedObjectState:
+                properties:
+                  lastPushedGitUser:
+                    type: string
+                  lastPushedObject:
+                    properties:
+                      group:
+                        type: string
+                      name:
+                        type: string
+                      resource:
+                        type: string
+                      version:
+                        type: string
+                    required:
+                    - group
+                    - name
+                    - resource
+                    - version
+                    type: object
+                  lastPushedObjectCommitHash:
+                    type: string
+                  lastPushedObjectGitPath:
+                    type: string
+                  lastPushedObjectGitRepo:
+                    type: string
+                  lastPushedObjectState:
+                    type: string
+                  lastPushedObjectTime:
+                    format: date-time
+                    type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: RemoteSyncer is the Schema for the remotesyncers API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: RemoteSyncerSpec defines the desired state of RemoteSyncer
+            properties:
+              bypassInterceptionSubjects:
+                items:
+                  description: |-
+                    Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,
+                    or a value for non-objects such as user and group names.
+                  properties:
+                    apiGroup:
+                      description: |-
+                        APIGroup holds the API group of the referenced subject.
+                        Defaults to "" for ServiceAccount subjects.
+                        Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                      type: string
+                    kind:
+                      description: |-
+                        Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount".
+                        If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                      type: string
+                    name:
+                      description: Name of the object being referenced.
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty
+                        the Authorizer should report an error.
+                      type: string
+                  required:
+                  - kind
+                  - name
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
+              caBundleSecretRef:
+                description: |-
+                  SecretReference represents a Secret Reference. It has enough information to retrieve secret
+                  in any namespace
+                properties:
+                  name:
+                    description: name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              defaultBlockAppliedMessage:
+                type: string
+              defaultBranch:
+                example: main
+                type: string
+              defaultRemoteUserRef:
+                description: |-
+                  ObjectReference contains enough information to let you inspect or modify the referred object.
+                  ---
+                  New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.
+                   1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.
+                   2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular
+                      restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".
+                      Those cannot be well described when embedded.
+                   3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.
+                   4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity
+                      during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple
+                      and the version of the actual struct is irrelevant.
+                   5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type
+                      will affect numerous schemas.  Don't make new APIs embed an underspecified API type they do not control.
+
+
+                  Instead of using this type, create a locally provided and used type that is well-focused on your reference.
+                  For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                      TODO: this design is not final and this field is subject to change in the future.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              defaultUnauthorizedUserMode:
+                default: Block
+                enum:
+                - Block
+                - UseDefaultUser
+                type: string
+              excludedFields:
+                items:
+                  type: string
+                type: array
+              excludedFieldsConfig:
+                description: |-
+                  ObjectReference contains enough information to let you inspect or modify the referred object.
+                  ---
+                  New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.
+                   1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.
+                   2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular
+                      restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".
+                      Those cannot be well described when embedded.
+                   3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.
+                   4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity
+                      during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple
+                      and the version of the actual struct is irrelevant.
+                   5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type
+                      will affect numerous schemas.  Don't make new APIs embed an underspecified API type they do not control.
+
+
+                  Instead of using this type, create a locally provided and used type that is well-focused on your reference.
+                  For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                      TODO: this design is not final and this field is subject to change in the future.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              insecureSkipTlsVerify:
+                type: boolean
+              processMode:
+                default: CommitApply
+                enum:
+                - CommitOnly
+                - CommitApply
+                type: string
+              pushMode:
+                default: SameBranch
+                enum:
+                - SameBranch
+                - MultipleBranch
+                - MergeRequest
+                type: string
+              remoteRepository:
+                example: https://git.example.com/my-repo.git
+                format: uri
+                type: string
+              rootPath:
+                type: string
+              scopedResources:
+                default: {}
+                properties:
+                  matchPolicy:
+                    description: MatchPolicyType specifies the type of match policy.
+                    type: string
+                  objectSelector:
+                    description: |-
+                      A label selector is a label query over a set of resources. The result of matchLabels and
+                      matchExpressions are ANDed. An empty label selector matches all objects. A null
+                      label selector matches no objects.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced during a strategic
+                                merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  rules:
+                    items:
+                      description: |-
+                        RuleWithOperations is a tuple of Operations and Resources. It is recommended to make
+                        sure that all the tuple expansions are valid.
+                      properties:
+                        apiGroups:
+                          description: |-
+                            APIGroups is the API groups the resources belong to. '*' is all groups.
+                            If '*' is present, the length of the slice must be one.
+                            Required.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        apiVersions:
+                          description: |-
+                            APIVersions is the API versions the resources belong to. '*' is all versions.
+                            If '*' is present, the length of the slice must be one.
+                            Required.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        operations:
+                          description: |-
+                            Operations is the operations the admission hook cares about - CREATE, UPDATE, DELETE, CONNECT or *
+                            for all of those operations and any future admission operations that are added.
+                            If '*' is present, the length of the slice must be one.
+                            Required.
+                          items:
+                            description: OperationType specifies an operation for
+                              a request.
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        resources:
+                          description: |-
+                            Resources is a list of resources this rule applies to.
+
+
+                            For example:
+                            'pods' means pods.
+                            'pods/log' means the log subresource of pods.
+                            '*' means all resources, but not subresources.
+                            'pods/*' means all subresources of pods.
+                            '*/scale' means all scale subresources.
+                            '*/*' means all resources and their subresources.
+
+
+                            If wildcard is present, the validation rule will ensure resources do not
+                            overlap with each other.
+
+
+                            Depending on the enclosing object, subresources might not be allowed.
+                            Required.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        scope:
+                          description: |-
+                            scope specifies the scope of this rule.
+                            Valid values are "Cluster", "Namespaced", and "*"
+                            "Cluster" means that only cluster-scoped resources will match this rule.
+                            Namespace API objects are cluster-scoped.
+                            "Namespaced" means that only namespaced resources will match this rule.
+                            "*" means that there are no scope restrictions.
+                            Subresources match the scope of their parent resource.
+                            Default is "*".
+                          type: string
+                      type: object
+                    type: array
+                type: object
+            required:
+            - defaultUnauthorizedUserMode
+            - processMode
+            - pushMode
+            - remoteRepository
+            - scopedResources
+            type: object
+          status:
+            properties:
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              lastBypassedObjectState:
+                properties:
+                  lastBypassObject:
+                    properties:
+                      group:
+                        type: string
+                      name:
+                        type: string
+                      resource:
+                        type: string
+                      version:
+                        type: string
+                    required:
+                    - group
+                    - name
+                    - resource
+                    - version
+                    type: object
+                  lastBypassObjectTime:
+                    format: date-time
+                    type: string
+                  lastBypassObjectUserInfo:
+                    description: |-
+                      UserInfo holds the information about the user needed to implement the
+                      user.Info interface.
+                    properties:
+                      extra:
+                        additionalProperties:
+                          description: ExtraValue masks the value so protobuf can
+                            generate
+                          items:
+                            type: string
+                          type: array
+                        description: Any additional information provided by the authenticator.
+                        type: object
+                      groups:
+                        description: The names of groups this user is a part of.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      uid:
+                        description: |-
+                          A unique value that identifies this user across time. If this user is
+                          deleted and another user by the same name is added, they will have
+                          different UIDs.
+                        type: string
+                      username:
+                        description: The name that uniquely identifies this user among
+                          all active users.
+                        type: string
+                    type: object
+                type: object
+              lastObservedObjectState:
+                properties:
+                  lastObservedObject:
+                    properties:
+                      group:
+                        type: string
+                      name:
+                        type: string
+                      resource:
+                        type: string
+                      version:
+                        type: string
+                    required:
+                    - group
+                    - name
+                    - resource
+                    - version
+                    type: object
+                  lastObservedObjectTime:
+                    format: date-time
+                    type: string
+                  lastObservedObjectUserInfo:
+                    description: |-
+                      UserInfo holds the information about the user needed to implement the
+                      user.Info interface.
+                    properties:
+                      extra:
+                        additionalProperties:
+                          description: ExtraValue masks the value so protobuf can
+                            generate
+                          items:
+                            type: string
+                          type: array
+                        description: Any additional information provided by the authenticator.
+                        type: object
+                      groups:
+                        description: The names of groups this user is a part of.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      uid:
+                        description: |-
+                          A unique value that identifies this user across time. If this user is
+                          deleted and another user by the same name is added, they will have
+                          different UIDs.
+                        type: string
+                      username:
+                        description: The name that uniquely identifies this user among
+                          all active users.
+                        type: string
+                    type: object
+                type: object
+              lastPushedObjectState:
+                properties:
+                  lastPushedGitUser:
+                    type: string
+                  lastPushedObject:
+                    properties:
+                      group:
+                        type: string
+                      name:
+                        type: string
+                      resource:
+                        type: string
+                      version:
+                        type: string
+                    required:
+                    - group
+                    - name
+                    - resource
+                    - version
+                    type: object
+                  lastPushedObjectCommitHash:
+                    type: string
+                  lastPushedObjectGitPath:
+                    type: string
+                  lastPushedObjectGitRepo:
+                    type: string
+                  lastPushedObjectState:
+                    type: string
+                  lastPushedObjectTime:
+                    format: date-time
+                    type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+{{- end }}

--- a/charts/0.2.0/templates/crd/syngit.syngit.io_remoteuser.yaml
+++ b/charts/0.2.0/templates/crd/syngit.syngit.io_remoteuser.yaml
@@ -1,0 +1,325 @@
+{{- if eq .Values.installCRD true }}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+    {{- if eq .Values.webhook.certmanager.enable true }}
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/operator-webhook-cert
+    {{- end }}
+  name: remoteusers.syngit.syngit.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          namespace: {{ .Release.Namespace }}
+          name: webhook-crd-service
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1
+  group: syngit.syngit.io
+  names:
+    categories:
+    - syngit
+    kind: RemoteUser
+    listKind: RemoteUserList
+    plural: remoteusers
+    shortNames:
+    - ru
+    - rus
+    singular: remoteuser
+  scope: Namespaced
+  versions:
+  - deprecated: true
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: RemoteUser is the Schema for the remoteusers API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              associatedRemoteUserBinding:
+                type: boolean
+              email:
+                type: string
+              gitBaseDomainFQDN:
+                type: string
+              secretRef:
+                description: |-
+                  SecretReference represents a Secret Reference. It has enough information to retrieve secret
+                  in any namespace
+                properties:
+                  name:
+                    description: name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+            required:
+            - associatedRemoteUserBinding
+            - email
+            - gitBaseDomainFQDN
+            - secretRef
+            type: object
+          status:
+            properties:
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              connexionStatus:
+                properties:
+                  details:
+                    type: string
+                  status:
+                    type: string
+                type: object
+              gitUser:
+                type: string
+              lastAuthTime:
+                format: date-time
+                type: string
+              secretBoundStatus:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: RemoteUser is the Schema for the remoteusers API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              email:
+                type: string
+              gitBaseDomainFQDN:
+                type: string
+              secretRef:
+                description: |-
+                  SecretReference represents a Secret Reference. It has enough information to retrieve secret
+                  in any namespace
+                properties:
+                  name:
+                    description: name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+            required:
+            - email
+            - gitBaseDomainFQDN
+            - secretRef
+            type: object
+          status:
+            properties:
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              connexionStatus:
+                properties:
+                  details:
+                    type: string
+                  status:
+                    type: string
+                type: object
+              gitUser:
+                type: string
+              lastAuthTime:
+                format: date-time
+                type: string
+              secretBoundStatus:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+{{- end }}

--- a/charts/0.2.0/templates/crd/syngit.syngit.io_remoteuserbinding.yaml
+++ b/charts/0.2.0/templates/crd/syngit.syngit.io_remoteuserbinding.yaml
@@ -1,0 +1,370 @@
+{{- if eq .Values.installCRD true }}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+    {{- if eq .Values.webhook.certmanager.enable true }}
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/operator-webhook-cert
+    {{- end }}
+  name: remoteuserbindings.syngit.syngit.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          namespace: {{ .Release.Namespace }}
+          name: webhook-crd-service
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1
+  group: syngit.syngit.io
+  names:
+    categories:
+    - syngit
+    kind: RemoteUserBinding
+    listKind: RemoteUserBindingList
+    plural: remoteuserbindings
+    shortNames:
+    - rub
+    - rubs
+    singular: remoteuserbinding
+  scope: Namespaced
+  versions:
+  - deprecated: true
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: RemoteUserBinding is the Schema for the remoteuserbindings API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              remoteRefs:
+                items:
+                  description: |-
+                    ObjectReference contains enough information to let you inspect or modify the referred object.
+                    ---
+                    New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.
+                     1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.
+                     2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular
+                        restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".
+                        Those cannot be well described when embedded.
+                     3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.
+                     4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity
+                        during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple
+                        and the version of the actual struct is irrelevant.
+                     5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type
+                        will affect numerous schemas.  Don't make new APIs embed an underspecified API type they do not control.
+
+
+                    Instead of using this type, create a locally provided and used type that is well-focused on your reference.
+                    For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: |-
+                        If referring to a piece of an object instead of an entire object, this string
+                        should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within a pod, this would take on a value like:
+                        "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]" (container with
+                        index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                        referencing a part of an object.
+                        TODO: this design is not final and this field is subject to change in the future.
+                      type: string
+                    kind:
+                      description: |-
+                        Kind of the referent.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                      type: string
+                    name:
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                      type: string
+                    resourceVersion:
+                      description: |-
+                        Specific resourceVersion to which this reference is made, if any.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                      type: string
+                    uid:
+                      description: |-
+                        UID of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
+              subject:
+                description: |-
+                  Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,
+                  or a value for non-objects such as user and group names.
+                properties:
+                  apiGroup:
+                    description: |-
+                      APIGroup holds the API group of the referenced subject.
+                      Defaults to "" for ServiceAccount subjects.
+                      Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount".
+                      If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                    type: string
+                  name:
+                    description: Name of the object being referenced.
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty
+                      the Authorizer should report an error.
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+            required:
+            - remoteRefs
+            - subject
+            type: object
+          status:
+            properties:
+              gitUserHosts:
+                items:
+                  properties:
+                    gitFQDN:
+                      type: string
+                    lastUsedTime:
+                      format: date-time
+                      type: string
+                    remoteUserUsed:
+                      type: string
+                    secretRef:
+                      description: |-
+                        SecretReference represents a Secret Reference. It has enough information to retrieve secret
+                        in any namespace
+                      properties:
+                        name:
+                          description: name is unique within a namespace to reference
+                            a secret resource.
+                          type: string
+                        namespace:
+                          description: namespace defines the space within which the
+                            secret name must be unique.
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    state:
+                      type: string
+                  required:
+                  - secretRef
+                  type: object
+                type: array
+              lastUsedTime:
+                format: date-time
+                type: string
+              state:
+                type: string
+              userKubernetesID:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: RemoteUserBinding is the Schema for the remoteuserbindings API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              remoteRefs:
+                items:
+                  description: |-
+                    ObjectReference contains enough information to let you inspect or modify the referred object.
+                    ---
+                    New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.
+                     1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.
+                     2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular
+                        restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".
+                        Those cannot be well described when embedded.
+                     3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.
+                     4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity
+                        during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple
+                        and the version of the actual struct is irrelevant.
+                     5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type
+                        will affect numerous schemas.  Don't make new APIs embed an underspecified API type they do not control.
+
+
+                    Instead of using this type, create a locally provided and used type that is well-focused on your reference.
+                    For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: |-
+                        If referring to a piece of an object instead of an entire object, this string
+                        should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within a pod, this would take on a value like:
+                        "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]" (container with
+                        index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                        referencing a part of an object.
+                        TODO: this design is not final and this field is subject to change in the future.
+                      type: string
+                    kind:
+                      description: |-
+                        Kind of the referent.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                      type: string
+                    name:
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                      type: string
+                    resourceVersion:
+                      description: |-
+                        Specific resourceVersion to which this reference is made, if any.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                      type: string
+                    uid:
+                      description: |-
+                        UID of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
+              subject:
+                description: |-
+                  Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,
+                  or a value for non-objects such as user and group names.
+                properties:
+                  apiGroup:
+                    description: |-
+                      APIGroup holds the API group of the referenced subject.
+                      Defaults to "" for ServiceAccount subjects.
+                      Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount".
+                      If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                    type: string
+                  name:
+                    description: Name of the object being referenced.
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty
+                      the Authorizer should report an error.
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+            required:
+            - remoteRefs
+            - subject
+            type: object
+          status:
+            properties:
+              gitUserHosts:
+                items:
+                  properties:
+                    gitFQDN:
+                      type: string
+                    lastUsedTime:
+                      format: date-time
+                      type: string
+                    remoteUserUsed:
+                      type: string
+                    secretRef:
+                      description: |-
+                        SecretReference represents a Secret Reference. It has enough information to retrieve secret
+                        in any namespace
+                      properties:
+                        name:
+                          description: name is unique within a namespace to reference
+                            a secret resource.
+                          type: string
+                        namespace:
+                          description: namespace defines the space within which the
+                            secret name must be unique.
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    state:
+                      type: string
+                  required:
+                  - secretRef
+                  type: object
+                type: array
+              lastUsedTime:
+                format: date-time
+                type: string
+              state:
+                type: string
+              userKubernetesID:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+{{- end }}

--- a/charts/0.2.0/templates/monitoring/monitor.yaml
+++ b/charts/0.2.0/templates/monitoring/monitor.yaml
@@ -1,0 +1,25 @@
+{{- if eq .Values.monitoring.enable true }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    control-plane: controller-manager
+    app.kubernetes.io/name: servicemonitor
+    app.kubernetes.io/instance: controller-manager-metrics-monitor
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  name: {{ .Release.Name }}-controller-manager-metrics-monitor
+spec:
+  endpoints:
+    - path: /metrics
+      port: https
+      scheme: https
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        insecureSkipVerify: true
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+{{- end }}

--- a/charts/0.2.0/templates/rbac/controller/auth_proxy_client_clusterrole.yaml
+++ b/charts/0.2.0/templates/rbac/controller/auth_proxy_client_clusterrole.yaml
@@ -1,0 +1,18 @@
+# {{- if eq .Values.controller.rbacProxy.enable true }}
+# ---
+# apiVersion: rbac.authorization.k8s.io/v1
+# kind: ClusterRole
+# metadata:
+#   labels:
+#     app.kubernetes.io/name: clusterrole
+#     app.kubernetes.io/instance: metrics-reader
+#     app.kubernetes.io/component: kube-rbac-proxy
+#     app.kubernetes.io/created-by: {{ .Release.Name }}
+#     app.kubernetes.io/part-of: {{ .Release.Name }}
+#   name: {{ .Release.Name }}-metrics-reader
+# rules:
+# - nonResourceURLs:
+#   - "/metrics"
+#   verbs:
+#   - get
+# {{- end }}

--- a/charts/0.2.0/templates/rbac/controller/auth_proxy_role.yaml
+++ b/charts/0.2.0/templates/rbac/controller/auth_proxy_role.yaml
@@ -1,0 +1,26 @@
+{{- if eq .Values.controller.rbacProxy.enable true }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/instance: proxy-role
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  name: {{ .Release.Name }}-proxy-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+{{- end }}

--- a/charts/0.2.0/templates/rbac/controller/auth_proxy_role_binding.yaml
+++ b/charts/0.2.0/templates/rbac/controller/auth_proxy_role_binding.yaml
@@ -1,0 +1,21 @@
+{{- if eq .Values.controller.rbacProxy.enable true }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: clusterrolebinding
+    app.kubernetes.io/instance: proxy-rolebinding
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  name: {{ .Release.Name }}-proxy-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Name }}-proxy-role
+subjects:
+- kind: ServiceAccount
+  name: {{ .Release.Name }}-controller-manager
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/0.2.0/templates/rbac/controller/leader_election_role.yaml
+++ b/charts/0.2.0/templates/rbac/controller/leader_election_role.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/name: role
+    app.kubernetes.io/instance: leader-election-role
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  name: {{ .Release.Name }}-leader-election-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch

--- a/charts/0.2.0/templates/rbac/controller/leader_election_role_binding.yaml
+++ b/charts/0.2.0/templates/rbac/controller/leader_election_role_binding.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: rolebinding
+    app.kubernetes.io/instance: leader-election-rolebinding
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  name: {{ .Release.Name }}-leader-election-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Release.Name }}-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: {{ .Release.Name }}-controller-manager
+  namespace: {{ .Release.Namespace }}

--- a/charts/0.2.0/templates/rbac/controller/role.yaml
+++ b/charts/0.2.0/templates/rbac/controller/role.yaml
@@ -2,8 +2,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: manager-role
+  name: {{ .Release.Name }}-manager-role
 rules:
+# Any resources can be pushed to the git repo.
+# The scope depends but the controller
+#  needs to be able to get,list,watch any of them
 - apiGroups:
   - '*'
   resources:
@@ -12,6 +15,14 @@ rules:
   - get
   - list
   - watch
+# Create and patch events related to kgio objects in any namespace
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 - apiGroups:
   - admissionregistration.k8s.io
   resources:
@@ -25,39 +36,9 @@ rules:
   - update
   - watch
 - apiGroups:
-  - authorization.k8s.io
+  - syngit.syngit.io
   resources:
-  - subjectaccessreviews
-  verbs:
-  - create
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - list
-  - patch
-  - watch
-- apiGroups:
-  - corev1
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - corev1
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
-- apiGroups:
-  - corev1
-  resources:
-  - secrets
+  - remoteusers
   verbs:
   - get
   - list
@@ -65,25 +46,7 @@ rules:
 - apiGroups:
   - syngit.syngit.io
   resources:
-  - remotesyncers
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - syngit.syngit.io
-  resources:
-  - remotesyncers/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - syngit.syngit.io
-  resources:
-  - remotesyncers/status
+  - remoteusers/status
   verbs:
   - get
   - patch
@@ -117,7 +80,7 @@ rules:
 - apiGroups:
   - syngit.syngit.io
   resources:
-  - remoteusers
+  - remotesyncers
   verbs:
   - create
   - delete
@@ -129,14 +92,20 @@ rules:
 - apiGroups:
   - syngit.syngit.io
   resources:
-  - remoteusers/finalizers
+  - remotesyncers/finalizers
   verbs:
   - update
 - apiGroups:
   - syngit.syngit.io
   resources:
-  - remoteusers/status
+  - remotesyncers/status
   verbs:
   - get
   - patch
   - update
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create

--- a/charts/0.2.0/templates/rbac/controller/role_binding.yaml
+++ b/charts/0.2.0/templates/rbac/controller/role_binding.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: clusterrolebinding
+    app.kubernetes.io/instance: manager-rolebinding
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  name: {{ .Release.Name }}-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Name }}-manager-role
+subjects:
+- kind: ServiceAccount
+  name: {{ .Release.Name }}-controller-manager
+  namespace: {{ .Release.Namespace }}

--- a/charts/0.2.0/templates/rbac/controller/service_account.yaml
+++ b/charts/0.2.0/templates/rbac/controller/service_account.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/name: serviceaccount
+    app.kubernetes.io/instance: controller-manager-sa
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  name: {{ .Release.Name }}-controller-manager

--- a/charts/0.2.0/templates/rbac/end-user/remotesyncer_editor_role.yaml
+++ b/charts/0.2.0/templates/rbac/end-user/remotesyncer_editor_role.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/instance: remotesyncers-editor-role
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  name: {{ .Release.Name }}-remotesyncers-editor-role
+rules:
+- apiGroups:
+  - syngit.syngit.io
+  resources:
+  - remotesyncerss
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - syngit.syngit.io
+  resources:
+  - remotesyncerss/status
+  verbs:
+  - get

--- a/charts/0.2.0/templates/rbac/end-user/remotesyncer_viewer_role.yaml
+++ b/charts/0.2.0/templates/rbac/end-user/remotesyncer_viewer_role.yaml
@@ -1,0 +1,26 @@
+# permissions for end users to view remotesyncerss.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/instance: remotesyncers-viewer-role
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  name: {{ .Release.Name }}-remotesyncers-viewer-role
+rules:
+- apiGroups:
+  - syngit.syngit.io
+  resources:
+  - remotesyncerss
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - syngit.syngit.io
+  resources:
+  - remotesyncerss/status
+  verbs:
+  - get

--- a/charts/0.2.0/templates/rbac/end-user/remoteuser_editor_role.yaml
+++ b/charts/0.2.0/templates/rbac/end-user/remoteuser_editor_role.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/instance: remoteuser-editor-role
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  name: {{ .Release.Name }}-remoteuser-editor-role
+rules:
+- apiGroups:
+  - syngit.syngit.io
+  resources:
+  - remoteusers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - syngit.syngit.io
+  resources:
+  - remoteusers/status
+  verbs:
+  - get

--- a/charts/0.2.0/templates/rbac/end-user/remoteuser_viewer_role.yaml
+++ b/charts/0.2.0/templates/rbac/end-user/remoteuser_viewer_role.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/instance: gitremote-viewer-role
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  name: {{ .Release.Name }}-gitremote-viewer-role
+rules:
+- apiGroups:
+  - syngit.syngit.io
+  resources:
+  - remoteusers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - syngit.syngit.io
+  resources:
+  - remoteusers/status
+  verbs:
+  - get

--- a/charts/0.2.0/templates/rbac/end-user/remoteuserbinding_editor_role.yaml
+++ b/charts/0.2.0/templates/rbac/end-user/remoteuserbinding_editor_role.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/instance: remoteuserbinding-editor-role
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  name: {{ .Release.Name }}-remoteuserbinding-editor-role
+rules:
+- apiGroups:
+  - syngit.syngit.io
+  resources:
+  - remoteuserbindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - syngit.syngit.io
+  resources:
+  - remoteuserbindings/status
+  verbs:
+  - get

--- a/charts/0.2.0/templates/rbac/end-user/remoteuserbinding_viewer_role.yaml
+++ b/charts/0.2.0/templates/rbac/end-user/remoteuserbinding_viewer_role.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/instance: remoteuserbinding-viewer-role
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  name: {{ .Release.Name }}-remoteuserbinding-viewer-role
+rules:
+- apiGroups:
+  - syngit.syngit.io
+  resources:
+  - remoteuserbindings
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - syngit.syngit.io
+  resources:
+  - remoteuserbindings/status
+  verbs:
+  - get

--- a/charts/0.2.0/templates/webhook/webhook-service.yaml
+++ b/charts/0.2.0/templates/webhook/webhook-service.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: service
+    app.kubernetes.io/instance: webhook-crd-service
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  name: webhook-crd-service
+spec:
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 9443
+  selector:
+    control-plane: controller-manager
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: service
+    app.kubernetes.io/instance: syngit-remote-syncer-webhook-service
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  name: syngit-remote-syncer-webhook-service
+spec:
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 9444
+  selector:
+    control-plane: controller-manager

--- a/charts/0.2.0/templates/webhook/webhook.yaml
+++ b/charts/0.2.0/templates/webhook/webhook.yaml
@@ -2,17 +2,21 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: validating-webhook-configuration
+  name: {{ .Release.Namespace }}-validating-webhook-configuration
+  {{- if eq .Values.webhook.certmanager.enable true }}
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/operator-webhook-cert
+  {{- end }}
 webhooks:
 - admissionReviewVersions:
   - v1
   clientConfig:
     service:
-      name: webhook-service
-      namespace: system
-      path: /validate-syngit-syngit-io-v1beta2-remotesyncer
+      name: webhook-crd-service
+      namespace: {{ .Release.Namespace }}
+      path: /validate-syngit-syngit-io-v1beta2-remoteuser
   failurePolicy: Fail
-  name: vremotesyncer-v1beta2.kb.io
+  name: vremoteuser.kb.io
   rules:
   - apiGroups:
     - syngit.syngit.io
@@ -22,14 +26,14 @@ webhooks:
     - CREATE
     - UPDATE
     resources:
-    - remotesyncers
+    - remoteusers
   sideEffects: None
 - admissionReviewVersions:
   - v1
   clientConfig:
     service:
-      name: webhook-service
-      namespace: system
+      name: webhook-crd-service
+      namespace: {{ .Release.Namespace }}
       path: /syngit-v1beta2-remotesyncer-rules-permissions
   failurePolicy: Fail
   name: vremotesyncers-rules-permissions.v1beta2.syngit.io
@@ -49,11 +53,11 @@ webhooks:
   - v1
   clientConfig:
     service:
-      name: webhook-service
-      namespace: system
-      path: /validate-syngit-syngit-io-v1beta2-remoteuser
+      name: webhook-crd-service
+      namespace: {{ .Release.Namespace }}
+      path: /validate-syngit-syngit-io-v1beta2-remotesyncer
   failurePolicy: Fail
-  name: vremoteuser-v1beta2.kb.io
+  name: vremotesyncer.kb.io
   rules:
   - apiGroups:
     - syngit.syngit.io
@@ -63,14 +67,14 @@ webhooks:
     - CREATE
     - UPDATE
     resources:
-    - remoteusers
+    - remotesyncers
   sideEffects: None
 - admissionReviewVersions:
   - v1
   clientConfig:
     service:
-      name: webhook-service
-      namespace: system
+      name: webhook-crd-service
+      namespace: {{ .Release.Namespace }}
       path: /syngit-v1beta2-remoteuser-association
   failurePolicy: Fail
   name: vremoteusers-association.v1beta2.syngit.io

--- a/charts/0.2.0/values.yaml
+++ b/charts/0.2.0/values.yaml
@@ -1,0 +1,70 @@
+webhook:
+  certmanager:
+    enable: true
+    certificate:
+      name: webhook-cert
+      secret: webhook-server-cert
+
+controller:
+  image:
+    prefix: ghcr.io/syngit-org
+    name: syngit
+    tag: 0.2.0
+    # imagePullSecrets:
+    # imagePullPolicy:
+
+  securityContext:
+    runAsUser: 1000
+    allowPrivilegeEscalation: false
+    privileged: false
+    runAsNonRoot: true
+    seccompProfile:
+      type: "RuntimeDefault"
+    capabilities:
+      drop:
+      - "ALL"
+  resources:
+    limits:
+      cpu: 500m
+      memory: 128Mi
+    requests:
+      cpu: 10m
+      memory: 64Mi
+  tolerations: []
+
+  metrics:
+    enable: false
+    bindAddress: 127.0.0.1:8080
+
+  rbacProxy:
+    enable: false
+    upstreamAddress: http://127.0.0.1:8080/
+    resources:
+      limits:
+        cpu: 500m
+        memory: 128Mi
+      requests:
+        cpu: 5m
+        memory: 64Mi
+    securityContext:
+      runAsUser: 1000
+      allowPrivilegeEscalation: false
+      privileged: false
+      runAsNonRoot: true
+      seccompProfile:
+        type: "RuntimeDefault"
+      capabilities:
+        drop:
+        - "ALL"
+
+  dynamicWebhookName: "remotesyncer.syngit.io"
+
+monitoring:
+  enable: false
+
+installCRD: true
+
+providers:
+  gitlab: false
+  github: false
+  bitbucket: false

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -179,6 +179,10 @@ func main() {
 		Client:  mgr.GetClient(),
 		Decoder: admission.NewDecoder(mgr.GetScheme()),
 	}})
+	mgr.GetWebhookServer().Register("/syngit-v1beta2-remotesyncer-rules-permissions", &webhook.Admission{Handler: &webhooksyngitv1beta2.RemoteSyncerWebhookHandler{
+		Client:  mgr.GetClient(),
+		Decoder: admission.NewDecoder(mgr.GetScheme()),
+	}})
 
 	//+kubebuilder:scaffold:builder
 

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,5 +5,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: local.cluster/syngit-controller
+  newName: local/syngit-controller
   newTag: dev

--- a/internal/controller/remotesyncer_controller.go
+++ b/internal/controller/remotesyncer_controller.go
@@ -48,6 +48,7 @@ type RemoteSyncerReconciler struct {
 //+kubebuilder:rbac:groups=*,resources=*,verbs=get;list;watch
 //+kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingwebhookconfigurations,verbs=create;get;list;watch;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=events,verbs=create;patch;list;watch
+//+kubebuilder:rbac:groups=authorization.k8s.io,resources=subjectaccessreviews,verbs=create
 
 func (r *RemoteSyncerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	_ = log.FromContext(ctx)

--- a/internal/webhook/v1beta2/remotesyncer_rules_permissions.go
+++ b/internal/webhook/v1beta2/remotesyncer_rules_permissions.go
@@ -1,0 +1,148 @@
+package v1beta2
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	admissionv1 "k8s.io/api/admissionregistration/v1"
+	v1 "k8s.io/api/authentication/v1"
+	authv1 "k8s.io/api/authorization/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	syngit "syngit.io/syngit/api/v1beta2"
+)
+
+type RemoteSyncerWebhookHandler struct {
+	Client  client.Client
+	Decoder *admission.Decoder
+}
+
+// +kubebuilder:webhook:path=/syngit-v1beta2-remotesyncer-rules-permissions,mutating=false,failurePolicy=fail,sideEffects=None,groups=syngit.syngit.io,resources=remotesyncers,verbs=create;update;delete,versions=v1beta2,admissionReviewVersions=v1,name=vremotesyncers-rules-permissions.v1beta2.syngit.io
+
+func (rswh *RemoteSyncerWebhookHandler) Handle(ctx context.Context, req admission.Request) admission.Response {
+
+	user := req.DeepCopy().UserInfo
+
+	rs := &syngit.RemoteSyncer{}
+
+	if string(req.Operation) != "DELETE" {
+		err := rswh.Decoder.Decode(req, rs)
+		if err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+	} else {
+		err := rswh.Decoder.DecodeRaw(req.OldObject, rs)
+		if err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+	}
+
+	if authorized, forbiddenResources, err := rswh.hasRightResourcesPermissions(*rs, user); err != nil {
+		return admission.Errored(http.StatusInternalServerError, err)
+	} else {
+		if authorized {
+			return admission.Allowed(fmt.Sprintf("The user %s is allowed to scope all of the listed resources", user))
+		} else {
+			return admission.Denied(fmt.Sprintf("The user %s is not allowed to scope: \n- %s", user, strings.Join(forbiddenResources, "\n- ")))
+		}
+	}
+}
+
+func (rswh *RemoteSyncerWebhookHandler) hasRightResourcesPermissions(rs syngit.RemoteSyncer, user v1.UserInfo) (bool, []string, error) {
+	forbiddenResourcesMap := map[string]string{}
+
+	for _, rule := range rs.Spec.ScopedResources.Rules {
+		for _, group := range rule.APIGroups {
+			for _, version := range rule.APIVersions {
+				for _, resource := range rule.Resources {
+
+					forbiddenOperations := []string{}
+
+					for _, operation := range rule.Operations {
+						verbs, err := operationToVerb(operation)
+						if err != nil {
+							// Skipping unsupported operation
+							continue
+						}
+						allowed := false
+
+						for _, verb := range verbs {
+							// Create a SubjectAccessReview
+							sar := &authv1.SubjectAccessReview{
+								Spec: authv1.SubjectAccessReviewSpec{
+									User:   user.Username,
+									Groups: user.Groups,
+									ResourceAttributes: &authv1.ResourceAttributes{
+										Namespace: rs.Namespace,
+										Verb:      verb,
+										Group:     group,
+										Version:   version,
+										Resource:  resource,
+									},
+								},
+							}
+							err := rswh.Client.Create(context.Background(), sar)
+							if err != nil {
+
+								if isInvalidCombinationError(err) {
+									// Skipping invalid combination
+									allowed = true
+									break
+								}
+
+								// For any other error, treat it as critical
+								return false, nil, err
+							}
+
+							if sar.Status.Allowed {
+								allowed = true
+								break
+							}
+						}
+						if !allowed {
+							forbiddenOperations = append(forbiddenOperations, string(operation))
+						}
+
+					}
+					if len(forbiddenOperations) > 0 {
+						forbiddenResourcesMap[fmt.Sprintf("%s/%s %s", group, version, resource)] = strings.Join(forbiddenOperations, ", ")
+					}
+				}
+			}
+		}
+	}
+
+	forbiddenResources := []string{}
+	for k, v := range forbiddenResourcesMap {
+		forbiddenResources = append(forbiddenResources, fmt.Sprintf("%s [%s]", k, v))
+	}
+
+	return len(forbiddenResources) == 0, forbiddenResources, nil
+}
+
+func operationToVerb(operation admissionv1.OperationType) ([]string, error) {
+	switch operation {
+	case admissionv1.Create:
+		return []string{"create"}, nil
+	case admissionv1.Delete:
+		return []string{"delete"}, nil
+	case admissionv1.Update:
+		return []string{"update", "patch"}, nil
+	case admissionv1.Connect:
+		return []string{"connect"}, nil
+	default:
+		return nil, fmt.Errorf("unsupported operation: %v", operation)
+	}
+}
+
+// Handle wrong apiVersion/Kind combination
+func isInvalidCombinationError(err error) bool {
+	errMsg := err.Error()
+	if strings.Contains(errMsg, "no matches for kind") ||
+		strings.Contains(errMsg, "could not find the requested resource") {
+		return true
+	}
+	return false
+}

--- a/internal/webhook/v1beta2/remotesyncer_webhook.go
+++ b/internal/webhook/v1beta2/remotesyncer_webhook.go
@@ -30,7 +30,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	. "syngit.io/syngit/api/v1beta2"
 	syngitv1beta2 "syngit.io/syngit/api/v1beta2"
 )
 
@@ -47,8 +46,6 @@ func SetupRemoteSyncerWebhookWithManager(mgr ctrl.Manager) error {
 
 // +kubebuilder:webhook:path=/validate-syngit-syngit-io-v1beta2-remotesyncer,mutating=false,failurePolicy=fail,sideEffects=None,groups=syngit.syngit.io,resources=remotesyncers,verbs=create;update,versions=v1beta2,name=vremotesyncer-v1beta2.kb.io,admissionReviewVersions=v1
 
-// NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
-// as this struct is used only for temporary operations and does not need to be deeply copied.
 type RemoteSyncerCustomValidator struct {
 	//TODO(user): Add more fields as needed for validation
 }
@@ -56,13 +53,13 @@ type RemoteSyncerCustomValidator struct {
 var _ webhook.CustomValidator = &RemoteSyncerCustomValidator{}
 
 // Validate validates the RemoteSyncerSpec
-func validateRemoteSyncerSpec(r *RemoteSyncerSpec) field.ErrorList {
+func validateRemoteSyncerSpec(r *syngitv1beta2.RemoteSyncerSpec) field.ErrorList {
 	var errors field.ErrorList
 
 	// Validate DefaultUserBind based on DefaultUnauthorizedUserMode
-	if r.DefaultUnauthorizedUserMode == Block && r.DefaultRemoteUserRef != nil {
+	if r.DefaultUnauthorizedUserMode == syngitv1beta2.Block && r.DefaultRemoteUserRef != nil {
 		errors = append(errors, field.Invalid(field.NewPath("spec").Child("defaultRemoteUserRef"), r.DefaultRemoteUserRef, "should not be set when defaultUnauthorizedUserMode is set to \"Block\""))
-	} else if r.DefaultUnauthorizedUserMode == UseDefaultUser && r.DefaultRemoteUserRef == nil {
+	} else if r.DefaultUnauthorizedUserMode == syngitv1beta2.UseDefaultUser && r.DefaultRemoteUserRef == nil {
 		errors = append(errors, field.Required(field.NewPath("spec").Child("defaultRemoteUserRef"), "must be set when defaultUnauthorizedUserMode is set to \"UseDefaultUser\""))
 	}
 
@@ -90,12 +87,12 @@ func validateRemoteSyncerSpec(r *RemoteSyncerSpec) field.ErrorList {
 	}
 
 	// Validate that DefaultBranch exists if PushMode is set to "SameBranch"
-	if r.PushMode == SameBranch && r.DefaultBranch == "" {
+	if r.PushMode == syngitv1beta2.SameBranch && r.DefaultBranch == "" {
 		errors = append(errors, field.Required(field.NewPath("spec").Child("defaultBranch"), "must be set when defaultBranch is set to \"SameBranch\""))
 	}
 
 	// Validate that DefaultBranch exists if DefaultUnauthorizedUser uses a default user
-	if r.DefaultUnauthorizedUserMode != Block && r.DefaultBranch == "" {
+	if r.DefaultUnauthorizedUserMode != syngitv1beta2.Block && r.DefaultBranch == "" {
 		errors = append(errors, field.Required(field.NewPath("spec").Child("defaultBranch"), "must be set when the defaultUnauthorizedUserMode is set to UseDefaultUser"))
 	}
 

--- a/internal/webhook/v1beta2/remoteuser_webhook.go
+++ b/internal/webhook/v1beta2/remoteuser_webhook.go
@@ -40,11 +40,8 @@ func SetupRemoteUserWebhookWithManager(mgr ctrl.Manager) error {
 		Complete()
 }
 
-//+kubebuilder:webhook:path=/validate-syngit-syngit-io-v1beta2-remoteuser,mutating=false,failurePolicy=fail,sideEffects=None,groups=syngit.syngit.io,resources=remoteusers,verbs=create;update,versions=v1beta2,name=vremoteuser-v1beta2.kb.io,admissionReviewVersions=v1
-//+kubebuilder:webhook:path=/syngit-v1beta2-remoteuser-association,mutating=false,failurePolicy=fail,sideEffects=None,groups=syngit.syngit.io,resources=remoteusers,verbs=create;delete,versions=v1beta2,admissionReviewVersions=v1,name=vremoteusers-association.v1beta2.syngit.io
+// +kubebuilder:webhook:path=/validate-syngit-syngit-io-v1beta2-remoteuser,mutating=false,failurePolicy=fail,sideEffects=None,groups=syngit.syngit.io,resources=remoteusers,verbs=create;update,versions=v1beta2,name=vremoteuser-v1beta2.kb.io,admissionReviewVersions=v1
 
-// NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
-// as this struct is used only for temporary operations and does not need to be deeply copied.
 type RemoteUserCustomValidator struct {
 	//TODO(user): Add more fields as needed for validation
 }

--- a/test/e2e/build/01_build_test.go
+++ b/test/e2e/build/01_build_test.go
@@ -47,10 +47,10 @@ var _ = Describe("01 Build & deploy controller", Ordered, func() {
 			err = utils.LoadImageToKindClusterWithName(projectimage)
 			ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
-			By("installing CRDs")
-			cmd = exec.Command("make", "install")
-			_, err = utils.Run(cmd)
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
+			// By("installing CRDs")
+			// cmd = exec.Command("make", "install")
+			// _, err = utils.Run(cmd)
+			// ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
 			By("deploying the controller-manager")
 			cmd = exec.Command("make", "dev-deploy")
@@ -93,17 +93,13 @@ var _ = Describe("01 Build & deploy controller", Ordered, func() {
 			}
 			EventuallyWithOffset(1, verifyControllerUp, time.Minute, time.Second).Should(Succeed())
 
-		})
-
-		It("should be uninstalled successfully", func() {
-			var err error
-
 			By("undeploying the controller-manager")
-			cmd := exec.Command("make", "cleanup-deploy")
+			cmd = exec.Command("make", "cleanup-deploy")
 			_, err = utils.Run(cmd)
 			ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
 		})
+
 	})
 
 })

--- a/test/e2e/syngit/01_setup_remoteusers_test.go
+++ b/test/e2e/syngit/01_setup_remoteusers_test.go
@@ -41,6 +41,7 @@ var _ = Describe("01 Create RemoteUser", func() {
 		err := syngit.AddToScheme(scheme.Scheme)
 		Expect(err).NotTo(HaveOccurred())
 
+		Wait5()
 		By("creating the RemoteUser for Luffy")
 		luffySecretName := string(Luffy) + "-creds"
 		remoteUserLuffy := &syngit.RemoteUser{
@@ -81,6 +82,7 @@ var _ = Describe("01 Create RemoteUser", func() {
 			return err == nil
 		}, timeout, interval).Should(BeTrue())
 
+		Wait5()
 		By("creating the RemoteUser for Sanji (without RemoteUserBinding)")
 		sanjiSecretName := string(Sanji) + "-creds"
 		remoteUserSanji := &syngit.RemoteUser{

--- a/test/e2e/syngit/02_commitonly_cm_test.go
+++ b/test/e2e/syngit/02_commitonly_cm_test.go
@@ -36,7 +36,7 @@ var _ = Describe("02 CommitOnly a ConfigMap", func() {
 	const (
 		cmName               = "test-cm2"
 		remoteUserLufffyName = "remoteuser-luffy"
-		remoteSyncerName     = "remotesyncer-test"
+		remoteSyncerName     = "remotesyncer-test2"
 	)
 
 	It("should not create the resource on the cluster", func() {
@@ -44,6 +44,7 @@ var _ = Describe("02 CommitOnly a ConfigMap", func() {
 		err := syngit.AddToScheme(scheme.Scheme)
 		Expect(err).NotTo(HaveOccurred())
 
+		Wait5()
 		By("creating the RemoteUser & RemoteUserBinding for Luffy")
 		luffySecretName := string(Luffy) + "-creds"
 		remoteUserLuffy := &syngit.RemoteUser{

--- a/test/e2e/syngit/03_commitapply_cm_test.go
+++ b/test/e2e/syngit/03_commitapply_cm_test.go
@@ -34,7 +34,7 @@ var _ = Describe("03 CommitApply a ConfigMap", func() {
 	ctx := context.TODO()
 
 	const (
-		remoteSyncerName    = "remotesyncer-test"
+		remoteSyncerName    = "remotesyncer-test3"
 		remoteUserLuffyName = "remoteuser-luffy"
 		cmName              = "test-cm3"
 	)
@@ -44,6 +44,7 @@ var _ = Describe("03 CommitApply a ConfigMap", func() {
 		err := syngit.AddToScheme(scheme.Scheme)
 		Expect(err).NotTo(HaveOccurred())
 
+		Wait5()
 		By("creating the RemoteUser & RemoteUserBinding for Luffy")
 		luffySecretName := string(Luffy) + "-creds"
 		remoteUserLuffy := &syngit.RemoteUser{

--- a/test/e2e/syngit/04_excludedfields_test.go
+++ b/test/e2e/syngit/04_excludedfields_test.go
@@ -37,7 +37,7 @@ var _ = Describe("04 Create RemoteSyncer with excluded fields", func() {
 		cmName1             = "test-cm4.1"
 		cmName2             = "test-cm4.2"
 		remoteUserLuffyName = "remoteuser-luffy"
-		remoteSyncerName    = "remotesyncer-test"
+		remoteSyncerName    = "remotesyncer-test4"
 	)
 
 	It("should exclude the selected fields from the git repo", func() {
@@ -45,6 +45,7 @@ var _ = Describe("04 Create RemoteSyncer with excluded fields", func() {
 		err := syngit.AddToScheme(scheme.Scheme)
 		Expect(err).NotTo(HaveOccurred())
 
+		Wait5()
 		By("creating the RemoteUser & RemoteUserBinding for Luffy")
 		luffySecretName := string(Luffy) + "-creds"
 		remoteUserLuffy := &syngit.RemoteUser{
@@ -221,7 +222,7 @@ var _ = Describe("04 Create RemoteSyncer with excluded fields", func() {
 		By("creating the RemoteSyncer")
 		remotesyncer := &syngit.RemoteSyncer{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "remotesyncer-test",
+				Name:      remoteSyncerName,
 				Namespace: namespace,
 			},
 			Spec: syngit.RemoteSyncerSpec{

--- a/test/e2e/syngit/05_defaultuser_test.go
+++ b/test/e2e/syngit/05_defaultuser_test.go
@@ -50,9 +50,12 @@ var _ = Describe("05 Use a default user", func() {
 
 		By("deleting the current Sanji remote user")
 		cmd = exec.Command("kubectl", "delete", "remoteuser", "-n", namespace, remoteUserSanjiName)
-		res, _ := Run(cmd)
-		fmt.Println(string(res))
+		res, delErr := Run(cmd)
+		if delErr != nil {
+			fmt.Println(string(res))
+		}
 
+		Wait5()
 		By("only creating the RemoteUser for Luffy")
 		luffySecretName := string(Luffy) + "-creds"
 		remoteUserLuffy := &syngit.RemoteUser{
@@ -73,6 +76,7 @@ var _ = Describe("05 Use a default user", func() {
 			return err == nil
 		}, timeout, interval).Should(BeTrue())
 
+		Wait5()
 		By("only creating the RemoteUser for Chopper")
 		chopperSecretName := string(Chopper) + "-creds"
 		remoteUserChopper := &syngit.RemoteUser{

--- a/test/e2e/syngit/06_objects_lifecycle_test.go
+++ b/test/e2e/syngit/06_objects_lifecycle_test.go
@@ -47,6 +47,7 @@ var _ = Describe("06 Test objects lifecycle", func() {
 
 		luffySecretName := string(Luffy) + "-creds"
 
+		Wait5()
 		By("creating the RemoteUser & RemoteUserBinding for Luffy (jupyter)")
 		remoteUserLuffyJupyter := &syngit.RemoteUser{
 			ObjectMeta: metav1.ObjectMeta{
@@ -140,6 +141,7 @@ var _ = Describe("06 Test objects lifecycle", func() {
 		err := syngit.AddToScheme(scheme.Scheme)
 		Expect(err).NotTo(HaveOccurred())
 
+		Wait5()
 		By("creating the RemoteUser & RemoteUserBinding for Luffy")
 		luffySecretName := string(Luffy) + "-creds"
 		remoteUserLuffy := &syngit.RemoteUser{

--- a/test/utils/.env
+++ b/test/utils/.env
@@ -8,6 +8,7 @@ ADMIN_EMAIL="syngit@example.com"                  # Admin email
 SANJI_USERNAME="sanji"
 CHOPPER_USERNAME="chopper-jb"
 LUFFY_USERNAME="luffy-jbg-sb"
+BROOK_USERNAME="brook-jbg-sb"
 
 PLATFORM1="jupyter"
 PLATFORM2="saturn"

--- a/test/utils/gitea.go
+++ b/test/utils/gitea.go
@@ -201,7 +201,7 @@ func searchForObjectInAllManifests(repo Repo, tree []Tree, obj runtime.Object) (
 		} else {
 			file, err := searchForObjectInAllManifests(repo, entry.Entries, obj)
 			if err != nil {
-				return nil, err
+				continue
 			}
 			if file != nil {
 				return file, nil

--- a/test/utils/gitea/setup-gitea-bind-platform1.sh
+++ b/test/utils/gitea/setup-gitea-bind-platform1.sh
@@ -35,7 +35,6 @@ fi
 #
 ## LUFFY
 #
-add-collaborator $GITEA_URL $ADMIN_TOKEN "blue" $LUFFY_USERNAME
 ADDED=$(add-collaborator $GITEA_URL $ADMIN_TOKEN "blue" $LUFFY_USERNAME)
 if [ "$ADDED" = "1" ]; then
   echo "User '$LUFFY_USERNAME' failed to be added to repository 'blue' with 'write' access on $PLATFORM1."
@@ -45,5 +44,22 @@ fi
 ADDED=$(add-collaborator $GITEA_URL $ADMIN_TOKEN "green" $LUFFY_USERNAME)
 if [ "$ADDED" = "1" ]; then
   echo "User '$LUFFY_USERNAME' failed to be added to repository 'green' with 'write' access on $PLATFORM1."
+  exit 1
+fi
+
+
+
+#
+## BROOK
+#
+ADDED=$(add-collaborator $GITEA_URL $ADMIN_TOKEN "blue" $BROOK_USERNAME)
+if [ "$ADDED" = "1" ]; then
+  echo "User '$BROOK_USERNAME' failed to be added to repository 'blue' with 'write' access on $PLATFORM1."
+  exit 1
+fi
+
+ADDED=$(add-collaborator $GITEA_URL $ADMIN_TOKEN "green" $BROOK_USERNAME)
+if [ "$ADDED" = "1" ]; then
+  echo "User '$BROOK_USERNAME' failed to be added to repository 'green' with 'write' access on $PLATFORM1."
   exit 1
 fi

--- a/test/utils/gitea/setup-gitea-bind-platform2.sh
+++ b/test/utils/gitea/setup-gitea-bind-platform2.sh
@@ -30,3 +30,12 @@ if [ "$ADDED" = "1" ]; then
   echo "User '$LUFFY_USERNAME' failed to be added to repository 'blue' with 'write' access on $PLATFORM2."
   exit 1
 fi
+
+#
+## BROOK
+#
+ADDED=$(add-collaborator $GITEA_URL $ADMIN_TOKEN "blue" $BROOK_USERNAME)
+if [ "$ADDED" = "1" ]; then
+  echo "User '$BROOK_USERNAME' failed to be added to repository 'blue' with 'write' access on $PLATFORM2."
+  exit 1
+fi

--- a/test/utils/gitea/setup-gitea-users.sh
+++ b/test/utils/gitea/setup-gitea-users.sh
@@ -69,3 +69,31 @@ kubectl exec -i $POD_NAME -n $NS_SATURN -- gitea admin user change-password \
   --username $LUFFY_USERNAME \
   --password $LUFFY_PWD \
   --must-change-password=false 2>&1 > /dev/null
+
+
+# brook-jbg-sb
+# Have access to the blue and green repo on the jupyter gitea
+# Have access to the blue repo on the saturn gitea
+BROOK_PWD="brook-jbg-sb-pwd"
+
+POD_NAME=$(kubectl get pods -n $NS_JUPYTER -l app.kubernetes.io/name=gitea -o jsonpath="{.items[0].metadata.name}")
+kubectl exec -i $POD_NAME -n $NS_JUPYTER -- gitea admin user create \
+  --username $BROOK_USERNAME \
+  --password "1$BROOK_PWD" \
+  --email "$BROOK_USERNAME@syngit.io" 2>&1 > /dev/null
+
+kubectl exec -i $POD_NAME -n $NS_JUPYTER -- gitea admin user change-password \
+  --username $BROOK_USERNAME \
+  --password $BROOK_PWD \
+  --must-change-password=false 2>&1 > /dev/null
+
+POD_NAME=$(kubectl get pods -n $NS_SATURN -l app.kubernetes.io/name=gitea -o jsonpath="{.items[0].metadata.name}")
+kubectl exec -i $POD_NAME -n $NS_SATURN -- gitea admin user create \
+  --username $BROOK_USERNAME \
+  --password "1$BROOK_PWD" \
+  --email "$BROOK_USERNAME@syngit.io" 2>&1 > /dev/null
+
+kubectl exec -i $POD_NAME -n $NS_SATURN -- gitea admin user change-password \
+  --username $BROOK_USERNAME \
+  --password $BROOK_PWD \
+  --must-change-password=false 2>&1 > /dev/null

--- a/test/utils/mock-users.go
+++ b/test/utils/mock-users.go
@@ -20,8 +20,11 @@ var (
 	Sanji   TestUser
 	Chopper TestUser
 	Luffy   TestUser
+	Brook   TestUser
 )
 
+var FullPermissionsUsers []TestUser
+var ReducedPermissionsUsers []TestUser
 var Users []TestUser
 
 type SyngitTestUsersClientset struct {
@@ -65,8 +68,11 @@ func (tu *SyngitTestUsersClientset) Initialize() error {
 	Sanji = TestUser(os.Getenv("SANJI_USERNAME"))
 	Chopper = TestUser(os.Getenv("CHOPPER_USERNAME"))
 	Luffy = TestUser(os.Getenv("LUFFY_USERNAME"))
+	Brook = TestUser(os.Getenv("BROOK_USERNAME"))
 
-	Users = []TestUser{Sanji, Chopper, Luffy}
+	FullPermissionsUsers = []TestUser{Sanji, Chopper, Luffy}
+	ReducedPermissionsUsers = []TestUser{Brook}
+	Users = append(FullPermissionsUsers, ReducedPermissionsUsers...)
 
 	kubeconfig := os.Getenv("KUBECONFIG")
 	if kubeconfig == "" {


### PR DESCRIPTION

AdThis PR add a webhook that will check for RBAC on CRUD for the `RemoteSyncer` object. It checks if the user that create the `RemoteSyncer` has the right permissions on the `scopedResources` of the `RemoteSyncer` he wants to CREATE/UPDATE/DELETE. It implements all of the needed tests

It solves #27 

Example:
Suppose an user that can only create configmaps.

Then, this is authorized:
```yaml
apiVersion: syngit.syngit.io/v1beta2
kind: RemoteSyncer
...
rules:
  scopedResources:
    rules:
    - apiGroups: [""]
      apiVersions: ["v1"]
      resources: ["configmaps"]
      operations: ["CREATE"]
```
But this one is not authorized:
```yaml
apiVersion: syngit.syngit.io/v1beta2
kind: RemoteSyncer
...
rules:
  scopedResources:
    rules:
    - apiGroups: [""]
      apiVersions: ["v1"]
      resources: ["configmaps"]
      operations: ["CREATE", "UPDATE", "DELETE"]
```

Add a small bug fix about the auto-generated `RemoteUserBinding` auto-update when a `RemoteUser` was updated.
Add a small bug fix about the conversion webhook