### PR TITLE
:seedling: Refactor tests

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - dev
     tags:
       - '*'
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,10 +4,15 @@ on:
   # run it on push to the default repository branch
   push:
     branches:
-      - main
-      - dev
+      - '*'
     tags:
       - '*'
+  pull_request:
+    types:
+      - opened
+      - reopened
+    branches:
+      - main
 
 jobs:
 

--- a/internal/webhook/v1beta2/remoteuser_association_webhook.go
+++ b/internal/webhook/v1beta2/remoteuser_association_webhook.go
@@ -80,11 +80,15 @@ func (ruwh *RemoteUserWebhookHandler) Handle(ctx context.Context, req admission.
 			return ruwh.removeRuFromRub(ctx, req, name, rub)
 		}
 
+		dontAppend := false
 		remoteRefs := rub.DeepCopy().Spec.RemoteRefs
 		for _, ruRef := range remoteRefs {
-			if ruRef.Name != ru.Name {
-				remoteRefs = append(remoteRefs, objRef)
+			if ruRef.Name == ru.Name {
+				dontAppend = true
 			}
+		}
+		if !dontAppend {
+			remoteRefs = append(remoteRefs, objRef)
 		}
 		rub.Spec.RemoteRefs = remoteRefs
 

--- a/test/e2e/build/01_build_test.go
+++ b/test/e2e/build/01_build_test.go
@@ -27,6 +27,8 @@ import (
 	"syngit.io/syngit/test/utils"
 )
 
+const projectimage = "local/syngit-controller:dev"
+
 var _ = Describe("01 Build & deploy controller", Ordered, func() {
 
 	Context("Operator", func() {
@@ -34,9 +36,6 @@ var _ = Describe("01 Build & deploy controller", Ordered, func() {
 		It("should run successfully", func() {
 			var controllerPodName string
 			var err error
-
-			// projectimage stores the name of the image used in the example
-			var projectimage = "local.cluster/syngit-controller:dev"
 
 			By("building the manager(Operator) image")
 			cmd := exec.Command("make", "docker-build", fmt.Sprintf("IMG=%s", projectimage))
@@ -46,11 +45,6 @@ var _ = Describe("01 Build & deploy controller", Ordered, func() {
 			By("loading the the manager(Operator) image on Kind")
 			err = utils.LoadImageToKindClusterWithName(projectimage)
 			ExpectWithOffset(1, err).NotTo(HaveOccurred())
-
-			// By("installing CRDs")
-			// cmd = exec.Command("make", "install")
-			// _, err = utils.Run(cmd)
-			// ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
 			By("deploying the controller-manager")
 			cmd = exec.Command("make", "dev-deploy")

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package e2e_build
+package e2e_test
 
 import (
 	"fmt"

--- a/test/e2e/syngit/01_setup_remoteusers_test.go
+++ b/test/e2e/syngit/01_setup_remoteusers_test.go
@@ -54,7 +54,7 @@ var _ = Describe("01 Create RemoteUser", func() {
 			},
 			Spec: syngit.RemoteUserSpec{
 				Email:             "sample@email.com",
-				GitBaseDomainFQDN: GitP1Fqdn,
+				GitBaseDomainFQDN: gitP1Fqdn,
 				SecretRef: corev1.SecretReference{
 					Name: luffySecretName,
 				},
@@ -92,7 +92,7 @@ var _ = Describe("01 Create RemoteUser", func() {
 			},
 			Spec: syngit.RemoteUserSpec{
 				Email:             "sample@email.com",
-				GitBaseDomainFQDN: GitP1Fqdn,
+				GitBaseDomainFQDN: gitP1Fqdn,
 				SecretRef: corev1.SecretReference{
 					Name: sanjiSecretName,
 				},

--- a/test/e2e/syngit/06_objects_lifecycle_test.go
+++ b/test/e2e/syngit/06_objects_lifecycle_test.go
@@ -59,7 +59,7 @@ var _ = Describe("06 Test objects lifecycle", func() {
 			},
 			Spec: syngit.RemoteUserSpec{
 				Email:             "sample@email.com",
-				GitBaseDomainFQDN: GitP1Fqdn,
+				GitBaseDomainFQDN: gitP1Fqdn,
 				SecretRef: corev1.SecretReference{
 					Name: luffySecretName,
 				},
@@ -81,7 +81,7 @@ var _ = Describe("06 Test objects lifecycle", func() {
 			},
 			Spec: syngit.RemoteUserSpec{
 				Email:             "sample@email.com",
-				GitBaseDomainFQDN: GitP2Fqdn,
+				GitBaseDomainFQDN: gitP2Fqdn,
 				SecretRef: corev1.SecretReference{
 					Name: luffySecretName,
 				},
@@ -89,6 +89,29 @@ var _ = Describe("06 Test objects lifecycle", func() {
 		}
 		Eventually(func() bool {
 			err := sClient.As(Luffy).CreateOrUpdate(remoteUserLuffySaturn)
+			return err == nil
+		}, timeout, interval).Should(BeTrue())
+
+		By("updating the RemoteUser & RemoteUserBinding for Luffy (saturn)")
+		remoteUserLuffySaturn2 := &syngit.RemoteUser{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      remoteUserLuffySaturnName,
+				Namespace: namespace,
+				Annotations: map[string]string{
+					"syngit.syngit.io/associated-remote-userbinding": "true",
+					"change": "something",
+				},
+			},
+			Spec: syngit.RemoteUserSpec{
+				Email:             "sample@email.com",
+				GitBaseDomainFQDN: gitP2Fqdn,
+				SecretRef: corev1.SecretReference{
+					Name: luffySecretName,
+				},
+			},
+		}
+		Eventually(func() bool {
+			err := sClient.As(Luffy).CreateOrUpdate(remoteUserLuffySaturn2)
 			return err == nil
 		}, timeout, interval).Should(BeTrue())
 
@@ -154,7 +177,7 @@ var _ = Describe("06 Test objects lifecycle", func() {
 			},
 			Spec: syngit.RemoteUserSpec{
 				Email:             "sample@email.com",
-				GitBaseDomainFQDN: GitP1Fqdn,
+				GitBaseDomainFQDN: gitP1Fqdn,
 				SecretRef: corev1.SecretReference{
 					Name: luffySecretName,
 				},
@@ -166,7 +189,7 @@ var _ = Describe("06 Test objects lifecycle", func() {
 		}, timeout, interval).Should(BeTrue())
 
 		Wait5()
-		repoUrl := "http://" + GitP1Fqdn + "/syngituser/blue.git"
+		repoUrl := "http://" + gitP1Fqdn + "/syngituser/blue.git"
 		By("creating the RemoteSyncer")
 		remotesyncer := &syngit.RemoteSyncer{
 			ObjectMeta: metav1.ObjectMeta{
@@ -222,28 +245,5 @@ var _ = Describe("06 Test objects lifecycle", func() {
 		}
 		Expect(stsNb).To(Equal(1))
 
-		By("deleting the remote syncer from the cluster")
-		Eventually(func() bool {
-			err := sClient.As(Luffy).Delete(remotesyncer)
-			return err == nil
-		}, timeout, interval).Should(BeTrue())
-
-		// Wait5()
-		// By("checking that the webhook does not intercept anything")
-		// Eventually(func() bool {
-		// 	err := sClient.As(Luffy).Get(nnValidation, getValidation)
-		// 	return err == nil
-		// }, timeout, interval).Should(BeTrue())
-
-		// validations = getValidation.Webhooks
-		// stsNb = 0
-		// for _, validation := range validations {
-		// 	rule := validation.Rules[0]
-		// 	if rule.Resources[0] == remotesyncer.Spec.ScopedResources.Rules[0].Resources[0] {
-		// 		stsNb += 1
-		// 	}
-		// }
-		// Expect(stsNb).To(Equal(0))
-		// Expect(len(validations)).To(Equal(0))
 	})
 })

--- a/test/e2e/syngit/07_bypass_subject_test.go
+++ b/test/e2e/syngit/07_bypass_subject_test.go
@@ -61,7 +61,7 @@ var _ = Describe("07 Subject bypasses interception", func() {
 			},
 			Spec: syngit.RemoteUserSpec{
 				Email:             "sample@email.com",
-				GitBaseDomainFQDN: GitP1Fqdn,
+				GitBaseDomainFQDN: gitP1Fqdn,
 				SecretRef: corev1.SecretReference{
 					Name: luffySecretName,
 				},
@@ -73,7 +73,7 @@ var _ = Describe("07 Subject bypasses interception", func() {
 		}, timeout, interval).Should(BeTrue())
 
 		Wait5()
-		repoUrl := "http://" + GitP1Fqdn + "/syngituser/blue.git"
+		repoUrl := "http://" + gitP1Fqdn + "/syngituser/blue.git"
 		By("creating the RemoteSyncer")
 		remotesyncer := &syngit.RemoteSyncer{
 			ObjectMeta: metav1.ObjectMeta{
@@ -122,15 +122,17 @@ var _ = Describe("07 Subject bypasses interception", func() {
 			ObjectMeta: metav1.ObjectMeta{Name: cmName, Namespace: namespace},
 			Data:       map[string]string{"test": "oui"},
 		}
-		_, err = sClient.KAs(Luffy).CoreV1().ConfigMaps(namespace).Create(ctx,
-			cm,
-			metav1.CreateOptions{},
-		)
-		Expect(err).ToNot(HaveOccurred())
+		Eventually(func() bool {
+			_, err = sClient.KAs(Luffy).CoreV1().ConfigMaps(namespace).Create(ctx,
+				cm,
+				metav1.CreateOptions{},
+			)
+			return err == nil
+		}, timeout, interval).Should(BeTrue())
 
 		By("checking that the configmap is not present on the repo")
 		repo := &Repo{
-			Fqdn:  GitP1Fqdn,
+			Fqdn:  gitP1Fqdn,
 			Owner: "syngituser",
 			Name:  "blue",
 		}
@@ -147,18 +149,6 @@ var _ = Describe("07 Subject bypasses interception", func() {
 
 		Eventually(func() bool {
 			err := sClient.As(Luffy).Get(nnCm, getCm)
-			return err == nil
-		}, timeout, interval).Should(BeTrue())
-
-		By("deleting the configmap from the cluster")
-		Eventually(func() bool {
-			err := sClient.As(Luffy).Delete(getCm)
-			return err == nil
-		}, timeout, interval).Should(BeTrue())
-
-		By("deleting the remote syncer from the cluster")
-		Eventually(func() bool {
-			err := sClient.As(Luffy).Delete(remotesyncer)
 			return err == nil
 		}, timeout, interval).Should(BeTrue())
 
@@ -185,7 +175,7 @@ var _ = Describe("07 Subject bypasses interception", func() {
 			},
 			Spec: syngit.RemoteUserSpec{
 				Email:             "sample@email.com",
-				GitBaseDomainFQDN: GitP1Fqdn,
+				GitBaseDomainFQDN: gitP1Fqdn,
 				SecretRef: corev1.SecretReference{
 					Name: luffySecretName,
 				},
@@ -197,7 +187,7 @@ var _ = Describe("07 Subject bypasses interception", func() {
 		}, timeout, interval).Should(BeTrue())
 
 		Wait5()
-		repoUrl := "http://" + GitP1Fqdn + "/syngituser/blue.git"
+		repoUrl := "http://" + gitP1Fqdn + "/syngituser/blue.git"
 		By("creating the RemoteSyncer")
 		remotesyncer := &syngit.RemoteSyncer{
 			ObjectMeta: metav1.ObjectMeta{
@@ -246,15 +236,17 @@ var _ = Describe("07 Subject bypasses interception", func() {
 			ObjectMeta: metav1.ObjectMeta{Name: cmName, Namespace: namespace},
 			Data:       map[string]string{"test": "oui"},
 		}
-		_, err = sClient.KAs(Luffy).CoreV1().ConfigMaps(namespace).Create(ctx,
-			cm,
-			metav1.CreateOptions{},
-		)
-		Expect(err).ToNot(HaveOccurred())
+		Eventually(func() bool {
+			_, err = sClient.KAs(Luffy).CoreV1().ConfigMaps(namespace).Create(ctx,
+				cm,
+				metav1.CreateOptions{},
+			)
+			return err == nil
+		}, timeout, interval).Should(BeTrue())
 
 		By("checking that the configmap is not present on the repo")
 		repo := &Repo{
-			Fqdn:  GitP1Fqdn,
+			Fqdn:  gitP1Fqdn,
 			Owner: "syngituser",
 			Name:  "blue",
 		}
@@ -271,18 +263,6 @@ var _ = Describe("07 Subject bypasses interception", func() {
 
 		Eventually(func() bool {
 			err := sClient.As(Luffy).Get(nnCm, getCm)
-			return err == nil
-		}, timeout, interval).Should(BeTrue())
-
-		By("deleting the configmap from the cluster")
-		Eventually(func() bool {
-			err := sClient.As(Luffy).Delete(getCm)
-			return err == nil
-		}, timeout, interval).Should(BeTrue())
-
-		By("deleting the remote syncer from the cluster")
-		Eventually(func() bool {
-			err := sClient.As(Luffy).Delete(remotesyncer)
 			return err == nil
 		}, timeout, interval).Should(BeTrue())
 

--- a/test/e2e/syngit/e2e_suite_test.go
+++ b/test/e2e/syngit/e2e_suite_test.go
@@ -18,9 +18,11 @@ package e2e_syngit
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
 	"time"
 
@@ -30,10 +32,13 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"syngit.io/syngit/test/utils"
 	. "syngit.io/syngit/test/utils"
+
+	syngit "syngit.io/syngit/api/v1beta2"
 )
 
 const (
@@ -50,9 +55,18 @@ const permissionsDeniedMessage = "is not allowed to scope"
 var cmd *exec.Cmd
 var sClient *SyngitTestUsersClientset
 
+const projectimage = "local/syngit-controller:dev"
+
+var setupType string
+var gitP1Fqdn string
+var gitP2Fqdn string
+
+func init() {
+	flag.StringVar(&setupType, "setup", "full", "Specify the setup type: fast or full")
+}
+
 // Run e2e tests using the Ginkgo runner.
 func TestE2E(t *testing.T) {
-
 	projectDir, err := utils.GetProjectDir()
 	if err != nil {
 		fmt.Fprintf(GinkgoWriter, "Failed to get project dir: %v\n", err)
@@ -63,27 +77,17 @@ func TestE2E(t *testing.T) {
 
 	RegisterFailHandler(Fail)
 	fmt.Fprintf(GinkgoWriter, "Starting syngit suite\n")
+	flag.Parse()
 	RunSpecs(t, "e2e suite syngit")
 }
 
 const reducedPermissionsCRName = "secret-rs-ru-cluster-role"
 
-var _ = BeforeSuite(func() {
-	ctx := context.TODO()
-	log.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
-
+func installationSetup() {
 	By("setuping gitea repos & users")
 	cmd = exec.Command("make", "setup-gitea")
 	_, err := Run(cmd)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
-
-	By("retrieving the gitea urls")
-	GitP1Fqdn, err = GetGiteaURL(os.Getenv("PLATFORM1"))
-	Expect(err).NotTo(HaveOccurred())
-	fmt.Printf("  Gitea URL for %s: %s\n", os.Getenv("PLATFORM1"), GitP1Fqdn)
-	GitP2Fqdn, err = GetGiteaURL(os.Getenv("PLATFORM2"))
-	Expect(err).NotTo(HaveOccurred())
-	fmt.Printf("  Gitea URL for %s: %s\n", os.Getenv("PLATFORM2"), GitP2Fqdn)
 
 	By("installing prometheus operator")
 	Expect(InstallPrometheusOperator()).To(Succeed())
@@ -91,18 +95,24 @@ var _ = BeforeSuite(func() {
 	By("installing the cert-manager")
 	Expect(InstallCertManager()).To(Succeed())
 
+	By("loading the the manager(Operator) image on Kind")
+	err = utils.LoadImageToKindClusterWithName(projectimage)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
 	By("installing the syngit chart")
 	cmd = exec.Command("make", "chart-install")
 	_, err = Run(cmd)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+}
 
+func rbacSetup(ctx context.Context) {
 	By("setting the default client successfully")
 	sClient = &SyngitTestUsersClientset{}
-	err = sClient.Initialize()
+	err := sClient.Initialize()
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
 	By("creating users with RBAC cluster-admin for global users")
-	for _, username := range FullPermissionsUsers {
+	for _, username := range append(FullPermissionsUsers, Admin) {
 		By(fmt.Sprintf("creating ClusterRoleBinding for the user %s", username))
 		_, err = sClient.KAs(Admin).RbacV1().ClusterRoleBindings().Create(ctx, &rbacv1.ClusterRoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
@@ -184,9 +194,12 @@ var _ = BeforeSuite(func() {
 			APIGroup: "rbac.authorization.k8s.io",
 		}))
 	}
+}
+
+func namespaceSetup(ctx context.Context) {
 
 	By("creating the test namespace")
-	_, err = sClient.KAs(Admin).CoreV1().Namespaces().Create(ctx,
+	_, err := sClient.KAs(Admin).CoreV1().Namespaces().Create(ctx,
 		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}},
 		metav1.CreateOptions{},
 	)
@@ -217,18 +230,66 @@ var _ = BeforeSuite(func() {
 		)
 		Expect(err).NotTo(HaveOccurred())
 	}
+}
+
+func isSetupInstalled() bool {
+	By("checking the gitea installation")
+	cmd = exec.Command("helm", "status", "gitea", "-n", os.Getenv("PLATFORM1"))
+	_, err := Run(cmd)
+	if err != nil {
+		return false
+	}
+	cmd = exec.Command("helm", "status", "gitea", "-n", os.Getenv("PLATFORM2"))
+	_, err = Run(cmd)
+	if err != nil {
+		return false
+	}
+
+	By("checking the cert-manager installation")
+	cmd = exec.Command("helm", "status", "cert-manager", "-n", "cert-manager")
+	_, err = Run(cmd)
+	if err != nil {
+		return false
+	}
+
+	By("checking the syngit installation")
+	cmd = exec.Command("helm", "status", "syngit", "-n", "syngit")
+	_, err = Run(cmd)
+	if err != nil {
+		return false
+	}
+
+	return true
+}
+
+var _ = BeforeSuite(func() {
+	ctx := context.TODO()
+	log.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	if setupType == "full" {
+		installationSetup()
+	}
+	if setupType == "fast" && !isSetupInstalled() {
+		installationSetup()
+	}
+	rbacSetup(ctx)
+	namespaceSetup(ctx)
+
+	By("retrieving the gitea urls")
+	var err error
+	gitP1Fqdn, err = GetGiteaURL(os.Getenv("PLATFORM1"))
+	Expect(err).NotTo(HaveOccurred())
+	fmt.Printf("  Gitea URL for %s: %s\n", os.Getenv("PLATFORM1"), gitP1Fqdn)
+	gitP2Fqdn, err = GetGiteaURL(os.Getenv("PLATFORM2"))
+	Expect(err).NotTo(HaveOccurred())
+	fmt.Printf("  Gitea URL for %s: %s\n", os.Getenv("PLATFORM2"), gitP2Fqdn)
 })
 
-var _ = AfterSuite(func() {
-	ctx := context.TODO()
-
+func uninstallSetup() {
 	By("uninstalling gitea")
 	cmd = exec.Command("make", "cleanup-gitea")
 	_, err := Run(cmd)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
-
-	By("uninstalling the Prometheus manager bundle")
-	UninstallPrometheusOperator()
 
 	By("uninstalling the cert-manager bundle")
 	UninstallCertManager()
@@ -242,18 +303,123 @@ var _ = AfterSuite(func() {
 	cmd = exec.Command("kubectl", "delete", "ns", operatorNamespace)
 	_, err = Run(cmd)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+}
+
+func deleteNamespace(ctx context.Context) {
 
 	By("deleting the test namespace")
-	err = sClient.KAs(Admin).CoreV1().Namespaces().Delete(ctx, namespace, metav1.DeleteOptions{GracePeriodSeconds: func() *int64 { i := int64(0); return &i }()})
+	err := sClient.KAs(Admin).CoreV1().Namespaces().Delete(ctx, namespace, metav1.DeleteOptions{GracePeriodSeconds: func() *int64 { i := int64(0); return &i }()})
 	Expect(err).NotTo(HaveOccurred())
+}
+
+func deleteRbac(ctx context.Context) {
 
 	By("deleting the global user's RBAC")
-	err = sClient.KAs(Admin).RbacV1().ClusterRoles().Delete(ctx, reducedPermissionsCRName, metav1.DeleteOptions{})
+	err := sClient.KAs(Admin).RbacV1().ClusterRoles().Delete(ctx, reducedPermissionsCRName, metav1.DeleteOptions{})
 	Expect(err).NotTo(HaveOccurred())
-	for _, username := range Users {
+	for _, username := range append(Users, Admin) {
 		By(fmt.Sprintf("deleting RBAC for the user %s", username))
 		err = sClient.KAs(Admin).RbacV1().ClusterRoleBindings().Delete(ctx, fmt.Sprintf("%s-cluster-role-binding", username), metav1.DeleteOptions{})
 		Expect(err).NotTo(HaveOccurred())
+	}
+
+}
+
+var _ = AfterSuite(func() {
+	ctx := context.TODO()
+	if setupType == "full" {
+		uninstallSetup()
+	}
+	By("uninstalling the Prometheus manager bundle")
+	UninstallPrometheusOperator()
+	deleteNamespace(ctx)
+	deleteRbac(ctx)
+})
+
+var _ = AfterEach(func() {
+	ctx := context.TODO()
+
+	By(fmt.Sprintf("deleting the remotesyncers from the %s ns", namespace))
+	remoteSyncers := &syngit.RemoteSyncerList{}
+	err := sClient.As(Admin).List(namespace, remoteSyncers)
+	if err == nil {
+		for _, remotesyncer := range remoteSyncers.Items {
+			nnRs := types.NamespacedName{
+				Name:      remotesyncer.Name,
+				Namespace: remotesyncer.Namespace,
+			}
+			rs := &syngit.RemoteSyncer{}
+			err = sClient.As(Admin).Get(nnRs, rs)
+			Expect(err).NotTo(HaveOccurred())
+			Eventually(func() bool {
+				err := sClient.As(Admin).Delete(remotesyncer.DeepCopy())
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+		}
+	}
+
+	By(fmt.Sprintf("deleting the remoteuserbindings from the %s ns", namespace))
+	remoteUserBindings := &syngit.RemoteUserBindingList{}
+	err = sClient.As(Admin).List(namespace, remoteUserBindings)
+	if err == nil {
+		for _, remoteuserbinding := range remoteUserBindings.Items {
+			nnRub := types.NamespacedName{
+				Name:      remoteuserbinding.Name,
+				Namespace: remoteuserbinding.Namespace,
+			}
+			rub := &syngit.RemoteUserBinding{}
+			err = sClient.As(Admin).Get(nnRub, rub)
+			Expect(err).NotTo(HaveOccurred())
+			Eventually(func() bool {
+				err := sClient.As(Admin).Delete(rub)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+		}
+	}
+
+	By(fmt.Sprintf("deleting the remoteusers from the %s ns", namespace))
+	remoteUsers := &syngit.RemoteUserList{}
+	err = sClient.As(Admin).List(namespace, remoteUsers)
+	if err == nil {
+		for _, remoteuser := range remoteUsers.Items {
+			nnRu := types.NamespacedName{
+				Name:      remoteuser.Name,
+				Namespace: remoteuser.Namespace,
+			}
+			ru := &syngit.RemoteUser{}
+			err = sClient.As(Admin).Get(nnRu, ru)
+			Expect(err).NotTo(HaveOccurred())
+			Eventually(func() bool {
+				err := sClient.As(Admin).Delete(ru)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+		}
+	}
+
+	By(fmt.Sprintf("deleting the test configmaps from the %s ns", namespace))
+	cms, err := sClient.KAs(Admin).CoreV1().ConfigMaps(namespace).List(ctx, metav1.ListOptions{})
+	if err == nil {
+		for _, cm := range cms.Items {
+			if strings.HasPrefix(cm.Name, "test-") {
+				Eventually(func() bool {
+					err = sClient.KAs(Admin).CoreV1().ConfigMaps(namespace).Delete(ctx, cm.Name, metav1.DeleteOptions{})
+					return err == nil
+				}, timeout, interval).Should(BeTrue())
+			}
+		}
+	}
+
+	By(fmt.Sprintf("deleting the test secrets from the %s ns", namespace))
+	secrets, err := sClient.KAs(Admin).CoreV1().Secrets(namespace).List(ctx, metav1.ListOptions{})
+	if err == nil {
+		for _, secret := range secrets.Items {
+			if strings.HasPrefix(secret.Name, "test-") {
+				Eventually(func() bool {
+					err = sClient.KAs(Admin).CoreV1().Secrets(namespace).Delete(ctx, secret.Name, metav1.DeleteOptions{})
+					return err == nil
+				}, timeout, interval).Should(BeTrue())
+			}
+		}
 	}
 
 })

--- a/test/utils/custom-client.go
+++ b/test/utils/custom-client.go
@@ -33,19 +33,14 @@ func (customClient CustomClient) CreateOrUpdate(obj client.Object) error {
 	return customClient.client.Update(customClient.ctx, obj)
 }
 
+func (customClient CustomClient) List(namespace string, objList client.ObjectList) error {
+	return customClient.client.List(customClient.ctx, objList, &client.ListOptions{Namespace: namespace})
+}
+
 func (customClient CustomClient) Get(namespacedName types.NamespacedName, obj client.Object) error {
 	return customClient.client.Get(customClient.ctx, namespacedName, obj)
 }
 
 func (customClient CustomClient) Delete(obj client.Object) error {
-	// Create a deep copy of the object to avoid modifying the input
-	existingObj := obj.DeepCopyObject().(client.Object)
-
-	// Check if the object exists
-	err := customClient.client.Get(customClient.ctx, client.ObjectKeyFromObject(obj), existingObj)
-	if err == nil {
-		return customClient.client.Delete(customClient.ctx, obj)
-	}
-
-	return nil
+	return customClient.client.Delete(customClient.ctx, obj)
 }

--- a/test/utils/gitea.go
+++ b/test/utils/gitea.go
@@ -65,9 +65,6 @@ type File struct {
 
 var Repos = map[string]Repo{}
 
-var GitP1Fqdn string
-var GitP2Fqdn string
-
 func getAdminToken(baseFqdn string) (string, error) {
 	const (
 		username = "syngituser"

--- a/test/utils/syngit.go
+++ b/test/utils/syngit.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"os/exec"
 
 	"gopkg.in/yaml.v2"
@@ -25,29 +24,6 @@ func GetGiteaURL(namespace string) (string, error) {
 
 	url := fmt.Sprintf("%s:%s", ip, port)
 	return url, nil
-}
-
-func RetrieveRepos() {
-	Repos[os.Getenv("PLATFORM1")+"-"+os.Getenv("REPO1")] = Repo{
-		Fqdn:  GitP1Fqdn,
-		Owner: os.Getenv("ADMIN_USERNAME"),
-		Name:  os.Getenv("REPO1"),
-	}
-	Repos[os.Getenv("PLATFORM1")+"-"+os.Getenv("REPO2")] = Repo{
-		Fqdn:  GitP1Fqdn,
-		Owner: os.Getenv("ADMIN_USERNAME"),
-		Name:  os.Getenv("REPO2"),
-	}
-	Repos[os.Getenv("PLATFORM2")+"-"+os.Getenv("REPO1")] = Repo{
-		Fqdn:  GitP2Fqdn,
-		Owner: os.Getenv("ADMIN_USERNAME"),
-		Name:  os.Getenv("REPO1"),
-	}
-	Repos[os.Getenv("PLATFORM2")+"-"+os.Getenv("REPO2")] = Repo{
-		Fqdn:  GitP2Fqdn,
-		Owner: os.Getenv("ADMIN_USERNAME"),
-		Name:  os.Getenv("REPO2"),
-	}
 }
 
 func AreObjectsUploaded(repo Repo, objects []runtime.Object) bool {


### PR DESCRIPTION
Add a test about `RemoteSyncer` that tests for multiple remotesyncers cross-creation with the exact same scoped Resources.
- Two `rs` that scope the same resources but have different target repository -> works fine
- Two `rs` that scope the same resources and have the same target repository -> inter-mutex locking

Add a test that update a `RemoteUser` and check that the associated `RemoteUserBinding` does not add a new `remoteRef`.

Refactor inter-tests compatibility. Tests are not inter-dependent anymore (even if they fail).

Add tests utilities :
- `make fast-e2e`: launch e2e test only for syngit part (and not the build part); moreover, if all of the utilities are already installed (`gitea`, `cert-manager` & `syngit`) then it will not try to re-install them -> it is supposed to be used when writing tests
- `make cleanup-e2e`: it is used when using `make dev-deploy` because they are not inter-compatible