### PR TITLE
:seedling: apiGroup conversion migrator

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,16 +3,7 @@ name: Tests
 on:
   # run it on push to the default repository branch
   push:
-    branches:
-      - '*'
-    tags:
-      - '*'
   pull_request:
-    types:
-      - opened
-      - reopened
-    branches:
-      - main
 
 jobs:
 

--- a/PROJECT
+++ b/PROJECT
@@ -2,7 +2,7 @@
 # This file is used to track the info used to scaffold your project
 # and allow the plugins properly work.
 # More info: https://book.kubebuilder.io/reference/project-config.html
-domain: syngit.io
+domain: io
 layout:
 - go.kubebuilder.io/v4
 projectName: syngit
@@ -12,7 +12,7 @@ resources:
     crdVersion: v1
     namespaced: true
   controller: true
-  domain: syngit.io
+  domain: io
   group: syngit
   kind: RemoteUser
   path: syngit.io/syngit/api/v1alpha1
@@ -24,7 +24,7 @@ resources:
     crdVersion: v1
     namespaced: true
   controller: true
-  domain: syngit.io
+  domain: io
   group: syngit
   kind: RemoteUserBinding
   path: syngit.io/syngit/api/v1alpha1
@@ -33,7 +33,7 @@ resources:
     crdVersion: v1
     namespaced: true
   controller: true
-  domain: syngit.io
+  domain: io
   group: syngit
   kind: RemoteSyncer
   path: syngit.io/syngit/api/v1alpha1
@@ -44,7 +44,7 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
-  domain: syngit.io
+  domain: io
   group: syngit
   kind: RemoteUser
   path: syngit.io/syngit/api/v1alpha2
@@ -55,7 +55,7 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
-  domain: syngit.io
+  domain: io
   group: syngit
   kind: RemoteUserBinding
   path: syngit.io/syngit/api/v1alpha2
@@ -63,7 +63,7 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
-  domain: syngit.io
+  domain: io
   group: syngit
   kind: RemoteSyncer
   path: syngit.io/syngit/api/v1alpha2
@@ -74,7 +74,7 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
-  domain: syngit.io
+  domain: io
   group: syngit
   kind: RemoteSyncer
   path: syngit.io/syngit/api/v1alpha3
@@ -85,7 +85,7 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
-  domain: syngit.io
+  domain: io
   group: syngit
   kind: RemoteUser
   path: syngit.io/syngit/api/v1alpha3
@@ -96,7 +96,7 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
-  domain: syngit.io
+  domain: io
   group: syngit
   kind: RemoteUserBinding
   path: syngit.io/syngit/api/v1alpha3
@@ -104,7 +104,7 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
-  domain: syngit.io
+  domain: io
   group: syngit
   kind: RemoteUserBinding
   path: syngit.io/syngit/api/v1alpha4
@@ -115,7 +115,7 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
-  domain: syngit.io
+  domain: io
   group: syngit
   kind: RemoteUser
   path: syngit.io/syngit/api/v1alpha4
@@ -126,7 +126,7 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
-  domain: syngit.io
+  domain: io
   group: syngit
   kind: RemoteSyncer
   path: syngit.io/syngit/api/v1alpha4
@@ -137,7 +137,7 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
-  domain: syngit.io
+  domain: io
   group: syngit
   kind: RemoteUser
   path: syngit.io/syngit/api/v1beta1
@@ -149,7 +149,7 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
-  domain: syngit.io
+  domain: io
   group: syngit
   kind: RemoteUserBinding
   path: syngit.io/syngit/api/v1beta1
@@ -160,7 +160,7 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
-  domain: syngit.io
+  domain: io
   group: syngit
   kind: RemoteSyncer
   path: syngit.io/syngit/api/v1beta1
@@ -172,7 +172,7 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
-  domain: syngit.io
+  domain: io
   group: syngit
   kind: RemoteSyncer
   path: syngit.io/syngit/api/v1beta2
@@ -184,7 +184,7 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
-  domain: syngit.io
+  domain: io
   group: syngit
   kind: RemoteUserBinding
   path: syngit.io/syngit/api/v1beta2
@@ -195,7 +195,7 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
-  domain: syngit.io
+  domain: io
   group: syngit
   kind: RemoteUser
   path: syngit.io/syngit/api/v1beta2

--- a/README.md
+++ b/README.md
@@ -50,12 +50,12 @@ stringData:
 ```
 
 ```yaml
-apiVersion: syngit.syngit.io/v1beta2
+apiVersion: syngit.io/v1beta2
 kind: RemoteUser
 metadata:
   name: remoteuser-sample
   annotations:
-    syngit.syngit.io/associated-remote-userbinding: "true"
+    syngit.io/associated-remote-userbinding: "true"
 spec:
   gitBaseDomainFQDN: "github.com"
   email: your@email.com
@@ -70,7 +70,7 @@ The RemoteSyncer object contains the whole logic part of the operator.
 In this example, the RemoteSyncer will intercept all the *configmaps* of the *default* namespace. It will push them to *https://github.com/my_repo_path.git* in the branch *main* under the path `my_configmaps/`. Because the `processMode` is set to `CommitApply`, the changes will be pushed and then applied to the cluster. `CommitOnly` will only push the resource on the git server without applying it on the cluster.
 
 ```yaml
-apiVersion: syngit.syngit.io/v1beta2
+apiVersion: syngit.io/v1beta2
 kind: RemoteSyncer
 metadata:
   name: remotesyncer-sample

--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the syngit v1alpha1 API group
 // +kubebuilder:object:generate=true
-// +groupName=syngit.syngit.io
+// +groupName=syngit.io
 package v1alpha1
 
 import (
@@ -26,7 +26,7 @@ import (
 
 var (
 	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: "syngit.syngit.io", Version: "v1alpha1"}
+	GroupVersion = schema.GroupVersion{Group: "syngit.io", Version: "v1alpha1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}

--- a/api/v1alpha2/groupversion_info.go
+++ b/api/v1alpha2/groupversion_info.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 // Package v1alpha2 contains API Schema definitions for the syngit v1alpha2 API group
 // +kubebuilder:object:generate=true
-// +groupName=syngit.syngit.io
+// +groupName=syngit.io
 package v1alpha2
 
 import (
@@ -26,7 +26,7 @@ import (
 
 var (
 	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: "syngit.syngit.io", Version: "v1alpha2"}
+	GroupVersion = schema.GroupVersion{Group: "syngit.io", Version: "v1alpha2"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}

--- a/api/v1alpha3/groupversion_info.go
+++ b/api/v1alpha3/groupversion_info.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 // Package v1alpha3 contains API Schema definitions for the syngit v1alpha3 API group
 // +kubebuilder:object:generate=true
-// +groupName=syngit.syngit.io
+// +groupName=syngit.io
 package v1alpha3
 
 import (
@@ -26,7 +26,7 @@ import (
 
 var (
 	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: "syngit.syngit.io", Version: "v1alpha3"}
+	GroupVersion = schema.GroupVersion{Group: "syngit.io", Version: "v1alpha3"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}

--- a/api/v1alpha4/groupversion_info.go
+++ b/api/v1alpha4/groupversion_info.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 // Package v1alpha4 contains API Schema definitions for the syngit v1alpha4 API group
 // +kubebuilder:object:generate=true
-// +groupName=syngit.syngit.io
+// +groupName=syngit.io
 package v1alpha4
 
 import (
@@ -26,7 +26,7 @@ import (
 
 var (
 	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: "syngit.syngit.io", Version: "v1alpha4"}
+	GroupVersion = schema.GroupVersion{Group: "syngit.io", Version: "v1alpha4"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}

--- a/api/v1beta1/groupversion_info.go
+++ b/api/v1beta1/groupversion_info.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 // Package v1beta1 contains API Schema definitions for the syngit v1beta1 API group
 // +kubebuilder:object:generate=true
-// +groupName=syngit.syngit.io
+// +groupName=syngit.io
 package v1beta1
 
 import (
@@ -26,7 +26,7 @@ import (
 
 var (
 	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: "syngit.syngit.io", Version: "v1beta1"}
+	GroupVersion = schema.GroupVersion{Group: "syngit.io", Version: "v1beta1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}

--- a/api/v1beta2/groupversion_info.go
+++ b/api/v1beta2/groupversion_info.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 // Package v1beta2 contains API Schema definitions for the syngit v1beta2 API group
 // +kubebuilder:object:generate=true
-// +groupName=syngit.syngit.io
+// +groupName=syngit.io
 package v1beta2
 
 import (
@@ -26,7 +26,7 @@ import (
 
 var (
 	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: "syngit.syngit.io", Version: "v1beta2"}
+	GroupVersion = schema.GroupVersion{Group: "syngit.io", Version: "v1beta2"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}

--- a/api/v1beta2/remotesyncer_types.go
+++ b/api/v1beta2/remotesyncer_types.go
@@ -102,7 +102,7 @@ type RemoteSyncerStatus struct {
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 //+kubebuilder:storageversion
-//+kubebuilder:resource:path=remotesyncers,shortName=rs;rss,categories=syngit
+//+kubebuilder:resource:path=remotesyncers,shortName=rsy;rsys,categories=syngit
 
 // RemoteSyncer is the Schema for the remotesyncers API
 type RemoteSyncer struct {

--- a/api/v1beta2/remoteuser_conversion.go
+++ b/api/v1beta2/remoteuser_conversion.go
@@ -43,7 +43,7 @@ func (src *RemoteUser) ConvertTo(dstRaw conversion.Hub) error {
 
 	// Renaming
 
-	associatedRemoteUserBinding, err := strconv.ParseBool(src.Annotations["syngit.syngit.io/associated-remote-userbinding"])
+	associatedRemoteUserBinding, err := strconv.ParseBool(src.Annotations["syngit.io/associated-remote-userbinding"])
 	if err != nil {
 		dst.Spec.AssociatedRemoteUserBinding = false
 	} else {
@@ -74,7 +74,7 @@ func (dst *RemoteUser) ConvertFrom(srcRaw conversion.Hub) error {
 	// Renaming
 
 	associatedRemoteUserBinding := strconv.FormatBool(src.Spec.AssociatedRemoteUserBinding)
-	dst.Annotations["syngit.syngit.io/associated-remote-userbinding"] = associatedRemoteUserBinding
+	dst.Annotations["syngit.io/associated-remote-userbinding"] = associatedRemoteUserBinding
 
 	return nil
 }

--- a/charts/0.2.0/templates/api-group-conversion/api-group-conversion-job-rbac.yaml
+++ b/charts/0.2.0/templates/api-group-conversion/api-group-conversion-job-rbac.yaml
@@ -1,0 +1,55 @@
+{{- if .Release.IsUpgrade -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: syngit-api-group-conversion
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+  name: syngit-api-group-conversion
+rules:
+- apiGroups:
+  - syngit.io
+  - syngit.syngit.io
+  resources:
+  - remotesyncers
+  - remotesyncers/status
+  - remoteusers
+  - remoteusers/status
+  - remoteuserbindings
+  - remoteuserbindings/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: syngit-api-group-conversion
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: syngit-api-group-conversion
+subjects:
+  - kind: ServiceAccount
+    name: syngit-api-group-conversion
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/0.2.0/templates/api-group-conversion/api-group-conversion-job.yaml
+++ b/charts/0.2.0/templates/api-group-conversion/api-group-conversion-job.yaml
@@ -1,0 +1,134 @@
+{{- if .Release.IsUpgrade -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: syngit-api-group-conversion
+  namespace: {{ .Release.Namespace }}
+spec:
+  template:
+    spec:
+      serviceAccountName: syngit-api-group-conversion
+      automountServiceAccountToken: true
+      containers:
+        - name: kubectl
+          image: bitnami/kubectl:latest
+          command: ["/bin/sh", "-c"]
+          args:
+            - |-
+              #!/bin/sh
+
+              sleep 60
+
+              echo "Checking for remoteusers"
+              GLOBAL_RUS=$(kubectl get remoteusers.syngit.syngit.io -A --no-headers -o=custom-columns="NAMESPACE:.metadata.namespace")
+              for RU_NS in $GLOBAL_RUS; do
+                for RU_NAME in $(kubectl get remoteusers.syngit.syngit.io -n $RU_NS --no-headers -o=custom-columns="NAMESPACE:.metadata.name"); do
+
+                  RU_SPEC=$(kubectl get remoteuser.syngit.syngit.io -n $RU_NS $RU_NAME -o json | jq '.spec')
+                  RU_LABELS=$(kubectl get remoteuser.syngit.syngit.io -n $RU_NS $RU_NAME -o json | jq '.metadata.labels')
+                  RU_ANNOTATIONS=$(kubectl get remoteuser.syngit.syngit.io -n $RU_NS $RU_NAME -o json | jq '.metadata.annotations')
+
+                  echo "Creating new remoteuser: ${RU_NAME}"
+                  NEW_RU_YAML=$(jq -n --arg name "${RU_NAME}" \
+                                        --arg namespace "$RU_NS" \
+                                        --argjson labels "$RU_LABELS" \
+                                        --argjson annotations "$RU_ANNOTATIONS" \
+                                        --argjson spec "$RU_SPEC" \
+                                        '
+                                        {
+                                          apiVersion: "syngit.io/v1beta2",
+                                          kind: "RemoteUser",
+                                          metadata: {
+                                            name: $name,
+                                            namespace: $namespace,
+                                            labels: $labels,
+                                            annotations: $annotations
+                                          },
+                                          spec: $spec
+                                        }
+                                        ')
+                  echo "${NEW_RU_YAML}" | yq eval -P - | kubectl apply -f -
+
+                done
+              done
+
+              echo "Checking for remoteuserbindings"
+              GLOBAL_RUBS=$(kubectl get remoteuserbindings.syngit.syngit.io -A --no-headers -o=custom-columns="NAMESPACE:.metadata.namespace")
+              for RUB_NS in $GLOBAL_RUBS; do
+                for RUB_NAME in $(kubectl get remoteuserbindings.syngit.syngit.io -n $RUB_NS --no-headers -o=custom-columns="NAMESPACE:.metadata.name"); do
+
+                  RUB_SPEC=$(kubectl get remoteuserbinding.syngit.syngit.io -n $RUB_NS $RUB_NAME -o json | jq '.spec')
+                  RUB_LABELS=$(kubectl get remoteuserbinding.syngit.syngit.io -n $RUB_NS $RUB_NAME -o json | jq '.metadata.labels')
+                  RUB_ANNOTATIONS=$(kubectl get remoteuserbinding.syngit.syngit.io -n $RUB_NS $RUB_NAME -o json | jq '.metadata.annotations')
+                
+                  echo "Creating new remoteuserbinding: ${RUB_NAME}"
+                  NEW_RUB_YAML=$(jq -n --arg name "${RUB_NAME}" \
+                                        --arg namespace "$RUB_NS" \
+                                        --argjson labels "$RU_LABELS" \
+                                        --argjson annotations "$RUB_ANNOTATIONS" \
+                                        --argjson spec "$RUB_SPEC" \
+                                        '
+                                        {
+                                          apiVersion: "syngit.io/v1beta2",
+                                          kind: "RemoteUserBinding",
+                                          metadata: {
+                                            name: $name,
+                                            namespace: $namespace,
+                                            labels: $labels,
+                                            annotations: $annotations
+                                          },
+                                          spec: $spec
+                                        }
+                                        ')
+                  echo "${NEW_RUB_YAML}" | yq eval -P - | kubectl apply -f -
+
+                done
+              done
+
+              echo "Checking for remotesyncers"
+              GLOBAL_RSYS=$(kubectl get remotesyncers.syngit.syngit.io -A --no-headers -o=custom-columns="NAMESPACE:.metadata.namespace")
+              for RSY_NS in $GLOBAL_RSYS; do
+                for RSY_NAME in $(kubectl get remotesyncers.syngit.syngit.io -n $RSY_NS --no-headers -o=custom-columns="NAMESPACE:.metadata.name"); do
+
+                  RSY_SPEC=$(kubectl get remotesyncer.syngit.syngit.io -n $RSY_NS $RSY_NAME -o json | jq '.spec')
+                  RSY_LABELS=$(kubectl get remotesyncer.syngit.syngit.io -n $RSY_NS $RSY_NAME -o json | jq '.metadata.labels')
+                  RSY_ANNOTATIONS=$(kubectl get remotesyncer.syngit.syngit.io -n $RSY_NS $RSY_NAME -o json | jq '.metadata.annotations')
+                
+                  echo "Creating new remotesyncer: ${RSY_NAME}"
+                  NEW_RSY_YAML=$(jq -n --arg name "${RSY_NAME}" \
+                                        --arg namespace "$RSY_NS" \
+                                        --argjson labels "$RSY_LABELS" \
+                                        --argjson annotations "$RSY_ANNOTATIONS" \
+                                        --argjson spec "$RSY_SPEC" \
+                                        '
+                                        {
+                                          apiVersion: "syngit.io/v1beta2",
+                                          kind: "RemoteSyncer",
+                                          metadata: {
+                                            name: $name,
+                                            namespace: $namespace,
+                                            labels: $labels,
+                                            annotations: $annotations
+                                          },
+                                          spec: $spec
+                                        }
+                                        ')
+                  echo "${NEW_RSY_YAML}" | yq eval -P - | kubectl apply -f -
+                  
+                done
+              done
+
+              echo "Deleting the old resources"
+              kubectl delete remoteusers.syngit.syngit.io --all
+              kubectl delete remoteuserbindings.syngit.syngit.io --all
+              kubectl delete remotesyncers.syngit.syngit.io --all
+
+              echo "Deleting the old CRDs"
+              kubectl delete crd remoteusers.syngit.syngit.io
+              kubectl delete crd remoteuserbindings.syngit.syngit.io
+              kubectl delete crd remotesyncers.syngit.syngit.io
+
+              echo "Success"
+              exit 0
+      restartPolicy: Never
+{{- end }}

--- a/charts/0.2.0/templates/crd/syngit.io_remotesyncer.yaml
+++ b/charts/0.2.0/templates/crd/syngit.io_remotesyncer.yaml
@@ -1,12 +1,27 @@
+{{- if eq .Values.installCRD true }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-  name: remotesyncers.syngit.syngit.io
+    {{- if eq .Values.webhook.certmanager.enable true }}
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/operator-webhook-cert
+    {{- end }}
+  name: remotesyncers.syngit.io
 spec:
-  group: syngit.syngit.io
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          namespace: {{ .Release.Namespace }}
+          name: webhook-crd-service
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1
+  group: syngit.io
   names:
     categories:
     - syngit
@@ -14,8 +29,8 @@ spec:
     listKind: RemoteSyncerList
     plural: remotesyncers
     shortNames:
-    - rs
-    - rss
+    - rsy
+    - rsys
     singular: remotesyncer
   scope: Namespaced
   versions:
@@ -1169,3 +1184,4 @@ spec:
     storage: true
     subresources:
       status: {}
+{{- end }}

--- a/charts/0.2.0/templates/crd/syngit.io_remoteuser.yaml
+++ b/charts/0.2.0/templates/crd/syngit.io_remoteuser.yaml
@@ -1,12 +1,27 @@
+{{- if eq .Values.installCRD true }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-  name: remoteusers.syngit.syngit.io
+    {{- if eq .Values.webhook.certmanager.enable true }}
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/operator-webhook-cert
+    {{- end }}
+  name: remoteusers.syngit.io
 spec:
-  group: syngit.syngit.io
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          namespace: {{ .Release.Namespace }}
+          name: webhook-crd-service
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1
+  group: syngit.io
   names:
     categories:
     - syngit
@@ -307,3 +322,4 @@ spec:
     storage: true
     subresources:
       status: {}
+{{- end }}

--- a/charts/0.2.0/templates/crd/syngit.io_remoteuserbinding.yaml
+++ b/charts/0.2.0/templates/crd/syngit.io_remoteuserbinding.yaml
@@ -1,5 +1,4 @@
 {{- if eq .Values.installCRD true }}
-{{- if .Release.IsUpgrade -}}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -9,7 +8,7 @@ metadata:
     {{- if eq .Values.webhook.certmanager.enable true }}
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/operator-webhook-cert
     {{- end }}
-  name: remoteuserbindings.syngit.syngit.io
+  name: remoteuserbindings.syngit.io
 spec:
   conversion:
     strategy: Webhook
@@ -22,7 +21,7 @@ spec:
           port: 443
       conversionReviewVersions:
       - v1
-  group: syngit.syngit.io
+  group: syngit.io
   names:
     categories:
     - syngit
@@ -368,5 +367,4 @@ spec:
     storage: true
     subresources:
       status: {}
-{{- end }}
 {{- end }}

--- a/charts/0.2.0/templates/rbac/controller/role.yaml
+++ b/charts/0.2.0/templates/rbac/controller/role.yaml
@@ -36,7 +36,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - syngit.syngit.io
+  - syngit.io
   resources:
   - remoteusers
   verbs:
@@ -44,7 +44,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - syngit.syngit.io
+  - syngit.io
   resources:
   - remoteusers/status
   verbs:
@@ -52,7 +52,7 @@ rules:
   - patch
   - update
 - apiGroups:
-  - syngit.syngit.io
+  - syngit.io
   resources:
   - remoteuserbindings
   verbs:
@@ -64,13 +64,13 @@ rules:
   - update
   - watch
 - apiGroups:
-  - syngit.syngit.io
+  - syngit.io
   resources:
   - remoteuserbindings/finalizers
   verbs:
   - update
 - apiGroups:
-  - syngit.syngit.io
+  - syngit.io
   resources:
   - remoteuserbindings/status
   verbs:
@@ -78,7 +78,7 @@ rules:
   - patch
   - update
 - apiGroups:
-  - syngit.syngit.io
+  - syngit.io
   resources:
   - remotesyncers
   verbs:
@@ -90,13 +90,13 @@ rules:
   - update
   - watch
 - apiGroups:
-  - syngit.syngit.io
+  - syngit.io
   resources:
   - remotesyncers/finalizers
   verbs:
   - update
 - apiGroups:
-  - syngit.syngit.io
+  - syngit.io
   resources:
   - remotesyncers/status
   verbs:

--- a/charts/0.2.0/templates/rbac/end-user/remotesyncer_editor_role.yaml
+++ b/charts/0.2.0/templates/rbac/end-user/remotesyncer_editor_role.yaml
@@ -11,9 +11,9 @@ metadata:
   name: {{ .Release.Name }}-remotesyncers-editor-role
 rules:
 - apiGroups:
-  - syngit.syngit.io
+  - syngit.io
   resources:
-  - remotesyncerss
+  - remotesyncers
   verbs:
   - create
   - delete
@@ -23,8 +23,8 @@ rules:
   - update
   - watch
 - apiGroups:
-  - syngit.syngit.io
+  - syngit.io
   resources:
-  - remotesyncerss/status
+  - remotesyncers/status
   verbs:
   - get

--- a/charts/0.2.0/templates/rbac/end-user/remotesyncer_viewer_role.yaml
+++ b/charts/0.2.0/templates/rbac/end-user/remotesyncer_viewer_role.yaml
@@ -1,4 +1,4 @@
-# permissions for end users to view remotesyncerss.
+# permissions for end users to view remotesyncers.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -11,16 +11,16 @@ metadata:
   name: {{ .Release.Name }}-remotesyncers-viewer-role
 rules:
 - apiGroups:
-  - syngit.syngit.io
+  - syngit.io
   resources:
-  - remotesyncerss
+  - remotesyncers
   verbs:
   - get
   - list
   - watch
 - apiGroups:
-  - syngit.syngit.io
+  - syngit.io
   resources:
-  - remotesyncerss/status
+  - remotesyncers/status
   verbs:
   - get

--- a/charts/0.2.0/templates/rbac/end-user/remoteuser_editor_role.yaml
+++ b/charts/0.2.0/templates/rbac/end-user/remoteuser_editor_role.yaml
@@ -11,7 +11,7 @@ metadata:
   name: {{ .Release.Name }}-remoteuser-editor-role
 rules:
 - apiGroups:
-  - syngit.syngit.io
+  - syngit.io
   resources:
   - remoteusers
   verbs:
@@ -23,7 +23,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - syngit.syngit.io
+  - syngit.io
   resources:
   - remoteusers/status
   verbs:

--- a/charts/0.2.0/templates/rbac/end-user/remoteuser_viewer_role.yaml
+++ b/charts/0.2.0/templates/rbac/end-user/remoteuser_viewer_role.yaml
@@ -11,7 +11,7 @@ metadata:
   name: {{ .Release.Name }}-gitremote-viewer-role
 rules:
 - apiGroups:
-  - syngit.syngit.io
+  - syngit.io
   resources:
   - remoteusers
   verbs:
@@ -19,7 +19,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - syngit.syngit.io
+  - syngit.io
   resources:
   - remoteusers/status
   verbs:

--- a/charts/0.2.0/templates/rbac/end-user/remoteuserbinding_editor_role.yaml
+++ b/charts/0.2.0/templates/rbac/end-user/remoteuserbinding_editor_role.yaml
@@ -11,7 +11,7 @@ metadata:
   name: {{ .Release.Name }}-remoteuserbinding-editor-role
 rules:
 - apiGroups:
-  - syngit.syngit.io
+  - syngit.io
   resources:
   - remoteuserbindings
   verbs:
@@ -23,7 +23,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - syngit.syngit.io
+  - syngit.io
   resources:
   - remoteuserbindings/status
   verbs:

--- a/charts/0.2.0/templates/rbac/end-user/remoteuserbinding_viewer_role.yaml
+++ b/charts/0.2.0/templates/rbac/end-user/remoteuserbinding_viewer_role.yaml
@@ -11,7 +11,7 @@ metadata:
   name: {{ .Release.Name }}-remoteuserbinding-viewer-role
 rules:
 - apiGroups:
-  - syngit.syngit.io
+  - syngit.io
   resources:
   - remoteuserbindings
   verbs:
@@ -19,7 +19,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - syngit.syngit.io
+  - syngit.io
   resources:
   - remoteuserbindings/status
   verbs:

--- a/charts/0.2.0/templates/webhook/webhook.yaml
+++ b/charts/0.2.0/templates/webhook/webhook.yaml
@@ -14,12 +14,12 @@ webhooks:
     service:
       name: webhook-crd-service
       namespace: {{ .Release.Namespace }}
-      path: /validate-syngit-syngit-io-v1beta2-remoteuser
+      path: /validate-syngit-io-v1beta2-remoteuser
   failurePolicy: Fail
   name: vremoteuser.kb.io
   rules:
   - apiGroups:
-    - syngit.syngit.io
+    - syngit.io
     apiVersions:
     - v1beta2
     operations:
@@ -39,7 +39,7 @@ webhooks:
   name: vremotesyncers-rules-permissions.v1beta2.syngit.io
   rules:
   - apiGroups:
-    - syngit.syngit.io
+    - syngit.io
     apiVersions:
     - v1beta2
     operations:
@@ -55,12 +55,12 @@ webhooks:
     service:
       name: webhook-crd-service
       namespace: {{ .Release.Namespace }}
-      path: /validate-syngit-syngit-io-v1beta2-remotesyncer
+      path: /validate-syngit-io-v1beta2-remotesyncer
   failurePolicy: Fail
   name: vremotesyncer.kb.io
   rules:
   - apiGroups:
-    - syngit.syngit.io
+    - syngit.io
     apiVersions:
     - v1beta2
     operations:
@@ -80,7 +80,7 @@ webhooks:
   name: vremoteusers-association.v1beta2.syngit.io
   rules:
   - apiGroups:
-    - syngit.syngit.io
+    - syngit.io
     apiVersions:
     - v1beta2
     operations:

--- a/config/crd/bases/syngit.io_remotesyncers.yaml
+++ b/config/crd/bases/syngit.io_remotesyncers.yaml
@@ -1,28 +1,12 @@
-{{- if eq .Values.installCRD true }}
-{{- if .Release.IsUpgrade -}}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    {{- if eq .Values.webhook.certmanager.enable true }}
-    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/operator-webhook-cert
-    {{- end }}
-  name: remotesyncers.syngit.syngit.io
+  name: remotesyncers.syngit.io
 spec:
-  conversion:
-    strategy: Webhook
-    webhook:
-      clientConfig:
-        service:
-          namespace: {{ .Release.Namespace }}
-          name: webhook-crd-service
-          path: /convert
-          port: 443
-      conversionReviewVersions:
-      - v1
-  group: syngit.syngit.io
+  group: syngit.io
   names:
     categories:
     - syngit
@@ -30,8 +14,8 @@ spec:
     listKind: RemoteSyncerList
     plural: remotesyncers
     shortNames:
-    - rs
-    - rss
+    - rsy
+    - rsys
     singular: remotesyncer
   scope: Namespaced
   versions:
@@ -1185,5 +1169,3 @@ spec:
     storage: true
     subresources:
       status: {}
-{{- end }}
-{{- end }}

--- a/config/crd/bases/syngit.io_remoteuserbindings.yaml
+++ b/config/crd/bases/syngit.io_remoteuserbindings.yaml
@@ -4,9 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-  name: remoteuserbindings.syngit.syngit.io
+  name: remoteuserbindings.syngit.io
 spec:
-  group: syngit.syngit.io
+  group: syngit.io
   names:
     categories:
     - syngit

--- a/config/crd/bases/syngit.io_remoteusers.yaml
+++ b/config/crd/bases/syngit.io_remoteusers.yaml
@@ -1,28 +1,12 @@
-{{- if eq .Values.installCRD true }}
-{{- if .Release.IsUpgrade -}}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    {{- if eq .Values.webhook.certmanager.enable true }}
-    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/operator-webhook-cert
-    {{- end }}
-  name: remoteusers.syngit.syngit.io
+  name: remoteusers.syngit.io
 spec:
-  conversion:
-    strategy: Webhook
-    webhook:
-      clientConfig:
-        service:
-          namespace: {{ .Release.Namespace }}
-          name: webhook-crd-service
-          path: /convert
-          port: 443
-      conversionReviewVersions:
-      - v1
-  group: syngit.syngit.io
+  group: syngit.io
   names:
     categories:
     - syngit
@@ -323,5 +307,3 @@ spec:
     storage: true
     subresources:
       status: {}
-{{- end }}
-{{- end }}

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -2,9 +2,9 @@
 # since it depends on service name and namespace that are out of this kustomize package.
 # It should be run by config/default
 resources:
-- bases/syngit.syngit.io_remoteusers.yaml
-- bases/syngit.syngit.io_remoteuserbindings.yaml
-- bases/syngit.syngit.io_remotesyncers.yaml
+- bases/syngit.io_remoteusers.yaml
+- bases/syngit.io_remoteuserbindings.yaml
+- bases/syngit.io_remotesyncers.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
 patches:

--- a/config/crd/patches/webhook_in_remotesyncers.yaml
+++ b/config/crd/patches/webhook_in_remotesyncers.yaml
@@ -2,7 +2,7 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: remotesyncers.syngit.syngit.io
+  name: remotesyncers.syngit.io
 spec:
   conversion:
     strategy: Webhook

--- a/config/crd/patches/webhook_in_remoteuserbindings.yaml
+++ b/config/crd/patches/webhook_in_remoteuserbindings.yaml
@@ -2,7 +2,7 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: remoteuserbindings.syngit.syngit.io
+  name: remoteuserbindings.syngit.io
 spec:
   conversion:
     strategy: Webhook

--- a/config/crd/patches/webhook_in_remoteusers.yaml
+++ b/config/crd/patches/webhook_in_remoteusers.yaml
@@ -2,7 +2,7 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: remoteusers.syngit.syngit.io
+  name: remoteusers.syngit.io
 spec:
   conversion:
     strategy: Webhook

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -63,7 +63,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - syngit.syngit.io
+  - syngit.io
   resources:
   - remotesyncers
   verbs:
@@ -75,13 +75,13 @@ rules:
   - update
   - watch
 - apiGroups:
-  - syngit.syngit.io
+  - syngit.io
   resources:
   - remotesyncers/finalizers
   verbs:
   - update
 - apiGroups:
-  - syngit.syngit.io
+  - syngit.io
   resources:
   - remotesyncers/status
   verbs:
@@ -89,7 +89,7 @@ rules:
   - patch
   - update
 - apiGroups:
-  - syngit.syngit.io
+  - syngit.io
   resources:
   - remoteuserbindings
   verbs:
@@ -101,13 +101,13 @@ rules:
   - update
   - watch
 - apiGroups:
-  - syngit.syngit.io
+  - syngit.io
   resources:
   - remoteuserbindings/finalizers
   verbs:
   - update
 - apiGroups:
-  - syngit.syngit.io
+  - syngit.io
   resources:
   - remoteuserbindings/status
   verbs:
@@ -115,7 +115,7 @@ rules:
   - patch
   - update
 - apiGroups:
-  - syngit.syngit.io
+  - syngit.io
   resources:
   - remoteusers
   verbs:
@@ -127,13 +127,13 @@ rules:
   - update
   - watch
 - apiGroups:
-  - syngit.syngit.io
+  - syngit.io
   resources:
   - remoteusers/finalizers
   verbs:
   - update
 - apiGroups:
-  - syngit.syngit.io
+  - syngit.io
   resources:
   - remoteusers/status
   verbs:

--- a/config/webhook/dev-webhook.yaml
+++ b/config/webhook/dev-webhook.yaml
@@ -7,12 +7,12 @@ webhooks:
 - admissionReviewVersions:
   - v1
   clientConfig:
-    url: https://172.17.0.1:9443/validate-syngit-syngit-io-v1-remoteuser
+    url: https://172.17.0.1:9443/validate-syngit-io-v1-remoteuser
   failurePolicy: Fail
   name: vremoteuser.kb.io
   rules:
   - apiGroups:
-    - syngit.syngit.io
+    - syngit.io
     apiVersions:
     - v1
     operations:
@@ -24,12 +24,12 @@ webhooks:
 - admissionReviewVersions:
   - v1
   clientConfig:
-    url: https://172.17.0.1:9443/validate-syngit-syngit-io-v1-remotesyncer
+    url: https://172.17.0.1:9443/validate-syngit-io-v1-remotesyncer
   failurePolicy: Fail
   name: vremotesyncer.kb.io
   rules:
   - apiGroups:
-    - syngit.syngit.io
+    - syngit.io
     apiVersions:
     - v1
     operations:

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -10,12 +10,12 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
-      path: /validate-syngit-syngit-io-v1beta2-remotesyncer
+      path: /validate-syngit-io-v1beta2-remotesyncer
   failurePolicy: Fail
   name: vremotesyncer-v1beta2.kb.io
   rules:
   - apiGroups:
-    - syngit.syngit.io
+    - syngit.io
     apiVersions:
     - v1beta2
     operations:
@@ -35,7 +35,7 @@ webhooks:
   name: vremotesyncers-rules-permissions.v1beta2.syngit.io
   rules:
   - apiGroups:
-    - syngit.syngit.io
+    - syngit.io
     apiVersions:
     - v1beta2
     operations:
@@ -51,12 +51,12 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
-      path: /validate-syngit-syngit-io-v1beta2-remoteuser
+      path: /validate-syngit-io-v1beta2-remoteuser
   failurePolicy: Fail
   name: vremoteuser-v1beta2.kb.io
   rules:
   - apiGroups:
-    - syngit.syngit.io
+    - syngit.io
     apiVersions:
     - v1beta2
     operations:
@@ -76,7 +76,7 @@ webhooks:
   name: vremoteusers-association.v1beta2.syngit.io
   rules:
   - apiGroups:
-    - syngit.syngit.io
+    - syngit.io
     apiVersions:
     - v1beta2
     operations:

--- a/internal/controller/remotesyncer_controller.go
+++ b/internal/controller/remotesyncer_controller.go
@@ -42,9 +42,9 @@ type RemoteSyncerReconciler struct {
 	Recorder      record.EventRecorder
 }
 
-//+kubebuilder:rbac:groups=syngit.syngit.io,resources=remotesyncers,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=syngit.syngit.io,resources=remotesyncers/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=syngit.syngit.io,resources=remotesyncers/finalizers,verbs=update
+//+kubebuilder:rbac:groups=syngit.io,resources=remotesyncers,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=syngit.io,resources=remotesyncers/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=syngit.io,resources=remotesyncers/finalizers,verbs=update
 //+kubebuilder:rbac:groups=*,resources=*,verbs=get;list;watch
 //+kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingwebhookconfigurations,verbs=create;get;list;watch;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=events,verbs=create;patch;list;watch

--- a/internal/controller/remoteuser_controller.go
+++ b/internal/controller/remoteuser_controller.go
@@ -44,9 +44,9 @@ type RemoteUserReconciler struct {
 	Namespace string
 }
 
-// +kubebuilder:rbac:groups=syngit.syngit.io,resources=remoteusers,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=syngit.syngit.io,resources=remoteusers/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=syngit.syngit.io,resources=remoteusers/finalizers,verbs=update
+// +kubebuilder:rbac:groups=syngit.io,resources=remoteusers,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=syngit.io,resources=remoteusers/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=syngit.io,resources=remoteusers/finalizers,verbs=update
 // +kubebuilder:rbac:groups=corev1,resources=secrets,verbs=get;list;watch
 // +kubebuilder:rbac:groups=corev1,resources=configmaps,verbs=get;list;watch
 // +kubebuilder:rbac:groups=corev1,resources=events,verbs=create;patch

--- a/internal/controller/remoteuser_controller_test.go
+++ b/internal/controller/remoteuser_controller_test.go
@@ -89,7 +89,7 @@ var _ = Describe("RemoteUser Controller", func() {
 						Name:      resourceNameAssociated,
 						Namespace: userNamespace,
 						Annotations: map[string]string{
-							"syngit.syngit.io/associated-remote-userbinding": "true",
+							"syngit.io/associated-remote-userbinding": "true",
 						},
 					},
 					Spec: syngit.RemoteUserSpec{

--- a/internal/controller/remoteuserbinding_controller.go
+++ b/internal/controller/remoteuserbinding_controller.go
@@ -41,9 +41,9 @@ type RemoteUserBindingReconciler struct {
 	Recorder record.EventRecorder
 }
 
-//+kubebuilder:rbac:groups=syngit.syngit.io,resources=remoteuserbindings,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=syngit.syngit.io,resources=remoteuserbindings/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=syngit.syngit.io,resources=remoteuserbindings/finalizers,verbs=update
+//+kubebuilder:rbac:groups=syngit.io,resources=remoteuserbindings,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=syngit.io,resources=remoteuserbindings/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=syngit.io,resources=remoteuserbindings/finalizers,verbs=update
 
 func (r *RemoteUserBindingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	_ = log.FromContext(ctx)

--- a/internal/controller/remoteuserbinding_controller_test.go
+++ b/internal/controller/remoteuserbinding_controller_test.go
@@ -74,7 +74,7 @@ var _ = Describe("RemoteUserBinding Controller", func() {
 						Name:      remoteusername,
 						Namespace: userNamespace,
 						Annotations: map[string]string{
-							"syngit.syngit.io/associated-remote-userbinding": "true",
+							"syngit.io/associated-remote-userbinding": "true",
 						},
 					},
 					Spec: syngit.RemoteUserSpec{

--- a/internal/webhook/v1beta2/remotesyncer_rules_permissions.go
+++ b/internal/webhook/v1beta2/remotesyncer_rules_permissions.go
@@ -19,7 +19,7 @@ type RemoteSyncerWebhookHandler struct {
 	Decoder *admission.Decoder
 }
 
-// +kubebuilder:webhook:path=/syngit-v1beta2-remotesyncer-rules-permissions,mutating=false,failurePolicy=fail,sideEffects=None,groups=syngit.syngit.io,resources=remotesyncers,verbs=create;update;delete,versions=v1beta2,admissionReviewVersions=v1,name=vremotesyncers-rules-permissions.v1beta2.syngit.io
+// +kubebuilder:webhook:path=/syngit-v1beta2-remotesyncer-rules-permissions,mutating=false,failurePolicy=fail,sideEffects=None,groups=syngit.io,resources=remotesyncers,verbs=create;update;delete,versions=v1beta2,admissionReviewVersions=v1,name=vremotesyncers-rules-permissions.v1beta2.syngit.io
 
 func (rswh *RemoteSyncerWebhookHandler) Handle(ctx context.Context, req admission.Request) admission.Response {
 

--- a/internal/webhook/v1beta2/remotesyncer_webhook.go
+++ b/internal/webhook/v1beta2/remotesyncer_webhook.go
@@ -44,7 +44,7 @@ func SetupRemoteSyncerWebhookWithManager(mgr ctrl.Manager) error {
 		Complete()
 }
 
-// +kubebuilder:webhook:path=/validate-syngit-syngit-io-v1beta2-remotesyncer,mutating=false,failurePolicy=fail,sideEffects=None,groups=syngit.syngit.io,resources=remotesyncers,verbs=create;update,versions=v1beta2,name=vremotesyncer-v1beta2.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/validate-syngit-io-v1beta2-remotesyncer,mutating=false,failurePolicy=fail,sideEffects=None,groups=syngit.io,resources=remotesyncers,verbs=create;update,versions=v1beta2,name=vremotesyncer-v1beta2.kb.io,admissionReviewVersions=v1
 
 type RemoteSyncerCustomValidator struct {
 	//TODO(user): Add more fields as needed for validation
@@ -116,7 +116,7 @@ func validateRemoteSyncer(remoteSyncer *syngitv1beta2.RemoteSyncer) error {
 	}
 
 	return apierrors.NewInvalid(
-		schema.GroupKind{Group: "syngit.syngit.io", Kind: "RemoteSyncer"},
+		schema.GroupKind{Group: "syngit.io", Kind: "RemoteSyncer"},
 		remoteSyncer.Name, allErrs)
 }
 

--- a/internal/webhook/v1beta2/remoteuser_association_webhook.go
+++ b/internal/webhook/v1beta2/remoteuser_association_webhook.go
@@ -21,7 +21,7 @@ type RemoteUserWebhookHandler struct {
 	Decoder *admission.Decoder
 }
 
-// +kubebuilder:webhook:path=/syngit-v1beta2-remoteuser-association,mutating=false,failurePolicy=fail,sideEffects=None,groups=syngit.syngit.io,resources=remoteusers,verbs=create;update;delete,versions=v1beta2,admissionReviewVersions=v1,name=vremoteusers-association.v1beta2.syngit.io
+// +kubebuilder:webhook:path=/syngit-v1beta2-remoteuser-association,mutating=false,failurePolicy=fail,sideEffects=None,groups=syngit.io,resources=remoteusers,verbs=create;update;delete,versions=v1beta2,admissionReviewVersions=v1,name=vremoteusers-association.v1beta2.syngit.io
 
 func (ruwh *RemoteUserWebhookHandler) Handle(ctx context.Context, req admission.Request) admission.Response {
 
@@ -52,7 +52,7 @@ func (ruwh *RemoteUserWebhookHandler) Handle(ctx context.Context, req admission.
 
 	if rubErr != nil {
 		// The RemoteUserBinding does not exists yet
-		if ru.Annotations["syngit.syngit.io/associated-remote-userbinding"] == "" || ru.Annotations["syngit.syngit.io/associated-remote-userbinding"] == "false" {
+		if ru.Annotations["syngit.io/associated-remote-userbinding"] == "" || ru.Annotations["syngit.io/associated-remote-userbinding"] == "false" {
 			return admission.Allowed("This object is not associated with any RemoteUserBinding")
 		}
 
@@ -76,7 +76,7 @@ func (ruwh *RemoteUserWebhookHandler) Handle(ctx context.Context, req admission.
 		}
 	} else {
 		// The RemoteUserBinding already exists
-		if ru.Annotations["syngit.syngit.io/associated-remote-userbinding"] == "" || ru.Annotations["syngit.syngit.io/associated-remote-userbinding"] == "false" {
+		if ru.Annotations["syngit.io/associated-remote-userbinding"] == "" || ru.Annotations["syngit.io/associated-remote-userbinding"] == "false" {
 			return ruwh.removeRuFromRub(ctx, req, name, rub)
 		}
 

--- a/internal/webhook/v1beta2/remoteuser_webhook.go
+++ b/internal/webhook/v1beta2/remoteuser_webhook.go
@@ -40,7 +40,7 @@ func SetupRemoteUserWebhookWithManager(mgr ctrl.Manager) error {
 		Complete()
 }
 
-// +kubebuilder:webhook:path=/validate-syngit-syngit-io-v1beta2-remoteuser,mutating=false,failurePolicy=fail,sideEffects=None,groups=syngit.syngit.io,resources=remoteusers,verbs=create;update,versions=v1beta2,name=vremoteuser-v1beta2.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/validate-syngit-io-v1beta2-remoteuser,mutating=false,failurePolicy=fail,sideEffects=None,groups=syngit.io,resources=remoteusers,verbs=create;update,versions=v1beta2,name=vremoteuser-v1beta2.kb.io,admissionReviewVersions=v1
 
 type RemoteUserCustomValidator struct {
 	//TODO(user): Add more fields as needed for validation

--- a/test/e2e/syngit/01_setup_remoteusers_test.go
+++ b/test/e2e/syngit/01_setup_remoteusers_test.go
@@ -49,7 +49,7 @@ var _ = Describe("01 Create RemoteUser", func() {
 				Name:      remoteUserLuffyName,
 				Namespace: namespace,
 				Annotations: map[string]string{
-					"syngit.syngit.io/associated-remote-userbinding": "true",
+					"syngit.io/associated-remote-userbinding": "true",
 				},
 			},
 			Spec: syngit.RemoteUserSpec{

--- a/test/e2e/syngit/02_commitonly_cm_test.go
+++ b/test/e2e/syngit/02_commitonly_cm_test.go
@@ -53,7 +53,7 @@ var _ = Describe("02 CommitOnly a ConfigMap", func() {
 				Name:      remoteUserLufffyName,
 				Namespace: namespace,
 				Annotations: map[string]string{
-					"syngit.syngit.io/associated-remote-userbinding": "true",
+					"syngit.io/associated-remote-userbinding": "true",
 				},
 			},
 			Spec: syngit.RemoteUserSpec{

--- a/test/e2e/syngit/03_commitapply_cm_test.go
+++ b/test/e2e/syngit/03_commitapply_cm_test.go
@@ -52,7 +52,7 @@ var _ = Describe("03 CommitApply a ConfigMap", func() {
 				Name:      remoteUserLuffyName,
 				Namespace: namespace,
 				Annotations: map[string]string{
-					"syngit.syngit.io/associated-remote-userbinding": "true",
+					"syngit.io/associated-remote-userbinding": "true",
 				},
 			},
 			Spec: syngit.RemoteUserSpec{

--- a/test/e2e/syngit/04_excludedfields_test.go
+++ b/test/e2e/syngit/04_excludedfields_test.go
@@ -54,7 +54,7 @@ var _ = Describe("04 Create RemoteSyncer with excluded fields", func() {
 				Name:      remoteUserLuffyName,
 				Namespace: namespace,
 				Annotations: map[string]string{
-					"syngit.syngit.io/associated-remote-userbinding": "true",
+					"syngit.io/associated-remote-userbinding": "true",
 				},
 			},
 			Spec: syngit.RemoteUserSpec{
@@ -181,7 +181,7 @@ var _ = Describe("04 Create RemoteSyncer with excluded fields", func() {
 				Name:      "remoteuser-luffy",
 				Namespace: namespace,
 				Annotations: map[string]string{
-					"syngit.syngit.io/associated-remote-userbinding": "true",
+					"syngit.io/associated-remote-userbinding": "true",
 				},
 			},
 			Spec: syngit.RemoteUserSpec{

--- a/test/e2e/syngit/06_objects_lifecycle_test.go
+++ b/test/e2e/syngit/06_objects_lifecycle_test.go
@@ -54,7 +54,7 @@ var _ = Describe("06 Test objects lifecycle", func() {
 				Name:      remoteUserLuffyJupyterName,
 				Namespace: namespace,
 				Annotations: map[string]string{
-					"syngit.syngit.io/associated-remote-userbinding": "true",
+					"syngit.io/associated-remote-userbinding": "true",
 				},
 			},
 			Spec: syngit.RemoteUserSpec{
@@ -76,7 +76,7 @@ var _ = Describe("06 Test objects lifecycle", func() {
 				Name:      remoteUserLuffySaturnName,
 				Namespace: namespace,
 				Annotations: map[string]string{
-					"syngit.syngit.io/associated-remote-userbinding": "true",
+					"syngit.io/associated-remote-userbinding": "true",
 				},
 			},
 			Spec: syngit.RemoteUserSpec{
@@ -98,7 +98,7 @@ var _ = Describe("06 Test objects lifecycle", func() {
 				Name:      remoteUserLuffySaturnName,
 				Namespace: namespace,
 				Annotations: map[string]string{
-					"syngit.syngit.io/associated-remote-userbinding": "true",
+					"syngit.io/associated-remote-userbinding": "true",
 					"change": "something",
 				},
 			},
@@ -172,7 +172,7 @@ var _ = Describe("06 Test objects lifecycle", func() {
 				Name:      remoteUserLuffyName,
 				Namespace: namespace,
 				Annotations: map[string]string{
-					"syngit.syngit.io/associated-remote-userbinding": "true",
+					"syngit.io/associated-remote-userbinding": "true",
 				},
 			},
 			Spec: syngit.RemoteUserSpec{

--- a/test/e2e/syngit/07_bypass_subject_test.go
+++ b/test/e2e/syngit/07_bypass_subject_test.go
@@ -56,7 +56,7 @@ var _ = Describe("07 Subject bypasses interception", func() {
 				Name:      remoteUserLuffyName,
 				Namespace: namespace,
 				Annotations: map[string]string{
-					"syngit.syngit.io/associated-remote-userbinding": "true",
+					"syngit.io/associated-remote-userbinding": "true",
 				},
 			},
 			Spec: syngit.RemoteUserSpec{
@@ -170,7 +170,7 @@ var _ = Describe("07 Subject bypasses interception", func() {
 				Name:      remoteUserLuffyName,
 				Namespace: namespace,
 				Annotations: map[string]string{
-					"syngit.syngit.io/associated-remote-userbinding": "true",
+					"syngit.io/associated-remote-userbinding": "true",
 				},
 			},
 			Spec: syngit.RemoteUserSpec{

--- a/test/e2e/syngit/08_webhook_rbac_test.go
+++ b/test/e2e/syngit/08_webhook_rbac_test.go
@@ -56,7 +56,7 @@ var _ = Describe("08 Webhook rbac checker", func() {
 				Name:      remoteUserBrookName,
 				Namespace: namespace,
 				Annotations: map[string]string{
-					"syngit.syngit.io/associated-remote-userbinding": "true",
+					"syngit.io/associated-remote-userbinding": "true",
 				},
 			},
 			Spec: syngit.RemoteUserSpec{
@@ -162,7 +162,7 @@ var _ = Describe("08 Webhook rbac checker", func() {
 				Name:      remoteUserBrookName,
 				Namespace: namespace,
 				Annotations: map[string]string{
-					"syngit.syngit.io/associated-remote-userbinding": "true",
+					"syngit.io/associated-remote-userbinding": "true",
 				},
 			},
 			Spec: syngit.RemoteUserSpec{

--- a/test/e2e/syngit/09_multi_remotesyncer_test.go
+++ b/test/e2e/syngit/09_multi_remotesyncer_test.go
@@ -56,7 +56,7 @@ var _ = Describe("09 Multi RemoteSyncer test", func() {
 				Name:      remoteUserLuffyName,
 				Namespace: namespace,
 				Annotations: map[string]string{
-					"syngit.syngit.io/associated-remote-userbinding": "true",
+					"syngit.io/associated-remote-userbinding": "true",
 				},
 			},
 			Spec: syngit.RemoteUserSpec{
@@ -204,7 +204,7 @@ var _ = Describe("09 Multi RemoteSyncer test", func() {
 				Name:      remoteUserLuffyName,
 				Namespace: namespace,
 				Annotations: map[string]string{
-					"syngit.syngit.io/associated-remote-userbinding": "true",
+					"syngit.io/associated-remote-userbinding": "true",
 				},
 			},
 			Spec: syngit.RemoteUserSpec{

--- a/test/e2e/syngit/e2e_suite_test.go
+++ b/test/e2e/syngit/e2e_suite_test.go
@@ -156,7 +156,7 @@ func rbacSetup(ctx context.Context) {
 			},
 			{
 				Verbs:     []string{"create", "get", "list", "watch", "update", "delete"},
-				APIGroups: []string{"syngit.syngit.io"},
+				APIGroups: []string{"syngit.io"},
 				Resources: []string{"remotesyncers", "remoteusers"},
 			},
 		},


### PR DESCRIPTION
The goal of this PR is to migrate the current CRD's domain (`syngit.io`) to just `io`. So the apiGroups of each CRDs will look like `syngit.io/v1beta2` instead of `syngit.syngit.io/v1beta2`.

The challenge here is to do a clean upgrade between the version `0.1.1` and `0.2.0`. Since we deliver syngit only using Helm charts. I provided a script (in a Job) to transform all the previous resources into the new ones. The job is executed once at the chart upgrade. If it is a first install, the script will not be executed and the CRDs will not be installed.

The chart provides the CRDs of the previous AND the new version in order to not trigger an auto-delete action of the previous CRDs (and so cascading delete the sub-resources). At the end of the script, the previous CRDs are deleted.

For the syngit version N+1, we have to remove the script and the previous CRDs as well.

For the release note, we have to say that the default annotation to associate a `RemoteUserBinding` is now `"syngit.io/associated-remote-userbinding": "true"` instead of `"syngit.syngit.io/associated-remote-userbinding": "true"`.