### PR TITLE
:sparkles: Add github & gitlab providers to the chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Syngit is a Kubernetes operator that allows you to push resources on a git repos
 ## Quick start
 
 ### Prerequisites
+- ⚠️ Cert Manager version 1.13+ on the cluster.
 - Helm version v3.0.0+.
-- Cert Manager version 1.13+ on the cluster.
 - Access to a Kubernetes v1.11.3+ cluster.
 
 ### Installation
@@ -27,7 +27,7 @@ helm repo add syngit https://syngit-org.github.io/syngit
 
 2. Install the operator
 ```sh
-helm install syngit syngit/syngit --version 0.2.0 -n syngit --create-namespace
+helm install syngit syngit/syngit --version 0.2.1 -n syngit --create-namespace --set providers.github.enabled="true"
 ```
 
 syngit is now installed on the cluster! More information about the configuration can be found on the [wiki](https://github.com/syngit-org/syngit/wiki/Installation).
@@ -56,6 +56,7 @@ metadata:
   name: remoteuser-sample
   annotations:
     syngit.io/associated-remote-userbinding: "true"
+    github.syngit.io/auth.test: "true"
 spec:
   gitBaseDomainFQDN: "github.com"
   email: your@email.com
@@ -139,7 +140,7 @@ As explained [here](https://github.com/syngit-org/syngit/wiki/🏗-Architecture)
 
 ## Wiki
 
-The [wiki](https://github.com/syngit-org/syngit/wiki) contains all the information needed!
+The [📚 Wiki](https://github.com/syngit-org/syngit/wiki) contains all the information needed!
 
 To dive deeper in the usage of Syngit (with ArgoCD for example), please refer to the [📖 Usage](https://github.com/syngit-org/syngit/wiki/📖-Usage) page.
 

--- a/charts/0.2.1/Chart.yaml
+++ b/charts/0.2.1/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: syngit
+description: An operator to push resources onto git
+type: application
+version: 0.2.1
+appVersion: 0.2.1
+home: https://github.com/syngit-org/syngit
+icon: https://raw.githubusercontent.com/syngit-org/syngit/main/img/icon.png
+maintainers:
+  - email: dassieu.damien@gmail.com
+    name: Damien

--- a/charts/0.2.1/templates/certmanager/certificate.yaml
+++ b/charts/0.2.1/templates/certmanager/certificate.yaml
@@ -1,0 +1,36 @@
+{{- if eq .Values.webhook.certmanager.enabled true }}
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    app.kubernetes.io/name: certificate
+    app.kubernetes.io/instance: serving-cert
+    app.kubernetes.io/component: certificate
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  name: {{ .Release.Name }}-selfsigned-issuer
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app.kubernetes.io/name: certificate
+    app.kubernetes.io/instance: serving-cert
+    app.kubernetes.io/component: certificate
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  name: operator-webhook-cert
+spec:
+  dnsNames:
+  - webhook-crd-service.{{ .Release.Namespace }}.svc
+  - webhook-crd-service.{{ .Release.Namespace }}.svc.local
+  - syngit-remote-syncer-webhook-service.{{ .Release.Namespace }}.svc
+  - syngit-remote-syncer-webhook-service.{{ .Release.Namespace }}.svc.local
+  issuerRef:
+    kind: Issuer
+    name: {{ .Release.Name }}-selfsigned-issuer
+  secretName: {{ .Values.webhook.certmanager.certificate.secret }}
+{{- end }}

--- a/charts/0.2.1/templates/controller/auth_proxy_service.yaml
+++ b/charts/0.2.1/templates/controller/auth_proxy_service.yaml
@@ -1,0 +1,22 @@
+{{- if eq .Values.controller.rbacProxy.enabled true }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    control-plane: controller-manager
+    app.kubernetes.io/name: service
+    app.kubernetes.io/instance: controller-manager-metrics-service
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  name: {{ .Release.Name }}-controller-manager-metrics-service
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: https
+  selector:
+    control-plane: controller-manager
+{{- end }}

--- a/charts/0.2.1/templates/controller/manager.yaml
+++ b/charts/0.2.1/templates/controller/manager.yaml
@@ -1,0 +1,99 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  labels:
+    control-plane: controller-manager
+    app.kubernetes.io/name: deployment
+    app.kubernetes.io/instance: controller-manager
+    app.kubernetes.io/component: manager
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+spec:
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        control-plane: controller-manager
+    spec:
+      {{- if .Values.controller.image.imagePullSecrets }}
+      imagePullSecrets:
+        {{ toYaml .Values.controller.image.imagePullSecrets | nindent 8 }}
+      {{- end }}
+      containers:
+      {{- if eq .Values.controller.metrics.enabled true }}
+      - name: kube-rbac-proxy
+        securityContext: {{ toYaml .Values.controller.rbacProxy.securityContext | nindent 10 }}
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
+        args:
+        - "--secure-listen-address=0.0.0.0:8443"
+        - "--upstream={{ .Values.controller.rbacProxy.upstreamAddress }}"
+        - "--logtostderr=true"
+        - "--v=0"
+        ports:
+        - containerPort: 8443
+          protocol: TCP
+          name: https
+        resources: {{ toYaml .Values.controller.rbacProxy.resources | nindent 10 }}
+      {{- end }}
+      - command:
+        - /manager
+        {{- if .Values.controller.image.imagePullPolicy }}
+        imagePullPolicy: {{ .Values.controller.image.imagePullPolicy }}
+        {{- end }}
+        args:
+        - "--leader-elect"
+        {{- if eq .Values.controller.metrics.enabled true }}
+        - "--health-probe-bind-address=:8081"
+        - "--metrics-bind-address={{ .Values.controller.metrics.bindAddress }}"
+        {{- end }}
+        image: {{ .Values.controller.image.prefix }}/{{ .Values.controller.image.name }}:{{ .Values.controller.image.tag }}
+        env:
+        - name: MANAGER_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: DYNAMIC_WEBHOOK_NAME
+          value: {{ .Values.controller.dynamicWebhookName }}
+        name: manager
+        securityContext: {{ toYaml .Values.controller.securityContext | nindent 10 }}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources: {{ toYaml .Values.controller.resources | nindent 10 }}
+        ports:
+        - containerPort: 9443
+          name: wbhk-crd-srv
+          protocol: TCP
+        - containerPort: 9444
+          name: wbhk-pusher-srv
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      serviceAccountName: {{ .Release.Name }}-controller-manager
+      terminationGracePeriodSeconds: 10
+      {{- if .Values.controller.tolerations }}
+      tolerations: {{ toYaml .Values.controller.tolerations | nindent 8 }}
+      {{- end }}
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: {{ .Values.webhook.certmanager.certificate.secret }}

--- a/charts/0.2.1/templates/crd/syngit.io_remotesyncer.yaml
+++ b/charts/0.2.1/templates/crd/syngit.io_remotesyncer.yaml
@@ -1,0 +1,1187 @@
+{{- if eq .Values.installCRD true }}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+    {{- if eq .Values.webhook.certmanager.enabled true }}
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/operator-webhook-cert
+    {{- end }}
+  name: remotesyncers.syngit.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          namespace: {{ .Release.Namespace }}
+          name: webhook-crd-service
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1
+  group: syngit.io
+  names:
+    categories:
+    - syngit
+    kind: RemoteSyncer
+    listKind: RemoteSyncerList
+    plural: remotesyncers
+    shortNames:
+    - rsy
+    - rsys
+    singular: remotesyncer
+  scope: Namespaced
+  versions:
+  - deprecated: true
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: RemoteSyncer is the Schema for the remotesyncers API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: RemoteSyncerSpec defines the desired state of RemoteSyncer
+            properties:
+              bypassInterceptionSubjects:
+                items:
+                  description: |-
+                    Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,
+                    or a value for non-objects such as user and group names.
+                  properties:
+                    apiGroup:
+                      description: |-
+                        APIGroup holds the API group of the referenced subject.
+                        Defaults to "" for ServiceAccount subjects.
+                        Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                      type: string
+                    kind:
+                      description: |-
+                        Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount".
+                        If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                      type: string
+                    name:
+                      description: Name of the object being referenced.
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty
+                        the Authorizer should report an error.
+                      type: string
+                  required:
+                  - kind
+                  - name
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
+              caBundle:
+                description: |-
+                  SecretReference represents a Secret Reference. It has enough information to retrieve secret
+                  in any namespace
+                properties:
+                  name:
+                    description: name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              defaultBlockAppliedMessage:
+                type: string
+              defaultBranch:
+                type: string
+              defaultUnauthorizedUserMode:
+                type: string
+              defaultUser:
+                description: |-
+                  ObjectReference contains enough information to let you inspect or modify the referred object.
+                  ---
+                  New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.
+                   1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.
+                   2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular
+                      restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".
+                      Those cannot be well described when embedded.
+                   3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.
+                   4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity
+                      during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple
+                      and the version of the actual struct is irrelevant.
+                   5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type
+                      will affect numerous schemas.  Don't make new APIs embed an underspecified API type they do not control.
+
+
+                  Instead of using this type, create a locally provided and used type that is well-focused on your reference.
+                  For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                      TODO: this design is not final and this field is subject to change in the future.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              excludedFields:
+                items:
+                  type: string
+                type: array
+              excludedFieldsConfig:
+                description: |-
+                  ObjectReference contains enough information to let you inspect or modify the referred object.
+                  ---
+                  New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.
+                   1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.
+                   2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular
+                      restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".
+                      Those cannot be well described when embedded.
+                   3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.
+                   4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity
+                      during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple
+                      and the version of the actual struct is irrelevant.
+                   5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type
+                      will affect numerous schemas.  Don't make new APIs embed an underspecified API type they do not control.
+
+
+                  Instead of using this type, create a locally provided and used type that is well-focused on your reference.
+                  For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                      TODO: this design is not final and this field is subject to change in the future.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              insecureSkipTlsVerify:
+                type: boolean
+              processMode:
+                type: string
+              pushMode:
+                type: string
+              remoteRepository:
+                format: uri
+                type: string
+              rootPath:
+                type: string
+              scopedResources:
+                properties:
+                  matchPolicy:
+                    description: MatchPolicyType specifies the type of match policy.
+                    type: string
+                  objectSelector:
+                    description: |-
+                      A label selector is a label query over a set of resources. The result of matchLabels and
+                      matchExpressions are ANDed. An empty label selector matches all objects. A null
+                      label selector matches no objects.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced during a strategic
+                                merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  rules:
+                    items:
+                      description: |-
+                        RuleWithOperations is a tuple of Operations and Resources. It is recommended to make
+                        sure that all the tuple expansions are valid.
+                      properties:
+                        apiGroups:
+                          description: |-
+                            APIGroups is the API groups the resources belong to. '*' is all groups.
+                            If '*' is present, the length of the slice must be one.
+                            Required.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        apiVersions:
+                          description: |-
+                            APIVersions is the API versions the resources belong to. '*' is all versions.
+                            If '*' is present, the length of the slice must be one.
+                            Required.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        operations:
+                          description: |-
+                            Operations is the operations the admission hook cares about - CREATE, UPDATE, DELETE, CONNECT or *
+                            for all of those operations and any future admission operations that are added.
+                            If '*' is present, the length of the slice must be one.
+                            Required.
+                          items:
+                            description: OperationType specifies an operation for
+                              a request.
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        resources:
+                          description: |-
+                            Resources is a list of resources this rule applies to.
+
+
+                            For example:
+                            'pods' means pods.
+                            'pods/log' means the log subresource of pods.
+                            '*' means all resources, but not subresources.
+                            'pods/*' means all subresources of pods.
+                            '*/scale' means all scale subresources.
+                            '*/*' means all resources and their subresources.
+
+
+                            If wildcard is present, the validation rule will ensure resources do not
+                            overlap with each other.
+
+
+                            Depending on the enclosing object, subresources might not be allowed.
+                            Required.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        scope:
+                          description: |-
+                            scope specifies the scope of this rule.
+                            Valid values are "Cluster", "Namespaced", and "*"
+                            "Cluster" means that only cluster-scoped resources will match this rule.
+                            Namespace API objects are cluster-scoped.
+                            "Namespaced" means that only namespaced resources will match this rule.
+                            "*" means that there are no scope restrictions.
+                            Subresources match the scope of their parent resource.
+                            Default is "*".
+                          type: string
+                      type: object
+                    type: array
+                type: object
+            required:
+            - defaultUnauthorizedUserMode
+            - processMode
+            - pushMode
+            - remoteRepository
+            type: object
+          status:
+            properties:
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              lastBypassedObjectState:
+                properties:
+                  lastBypassObject:
+                    properties:
+                      group:
+                        type: string
+                      name:
+                        type: string
+                      resource:
+                        type: string
+                      version:
+                        type: string
+                    required:
+                    - group
+                    - name
+                    - resource
+                    - version
+                    type: object
+                  lastBypassObjectTime:
+                    format: date-time
+                    type: string
+                  lastBypassObjectUserInfo:
+                    description: |-
+                      UserInfo holds the information about the user needed to implement the
+                      user.Info interface.
+                    properties:
+                      extra:
+                        additionalProperties:
+                          description: ExtraValue masks the value so protobuf can
+                            generate
+                          items:
+                            type: string
+                          type: array
+                        description: Any additional information provided by the authenticator.
+                        type: object
+                      groups:
+                        description: The names of groups this user is a part of.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      uid:
+                        description: |-
+                          A unique value that identifies this user across time. If this user is
+                          deleted and another user by the same name is added, they will have
+                          different UIDs.
+                        type: string
+                      username:
+                        description: The name that uniquely identifies this user among
+                          all active users.
+                        type: string
+                    type: object
+                type: object
+              lastObservedObjectState:
+                properties:
+                  lastObservedObject:
+                    properties:
+                      group:
+                        type: string
+                      name:
+                        type: string
+                      resource:
+                        type: string
+                      version:
+                        type: string
+                    required:
+                    - group
+                    - name
+                    - resource
+                    - version
+                    type: object
+                  lastObservedObjectTime:
+                    format: date-time
+                    type: string
+                  lastObservedObjectUserInfo:
+                    description: |-
+                      UserInfo holds the information about the user needed to implement the
+                      user.Info interface.
+                    properties:
+                      extra:
+                        additionalProperties:
+                          description: ExtraValue masks the value so protobuf can
+                            generate
+                          items:
+                            type: string
+                          type: array
+                        description: Any additional information provided by the authenticator.
+                        type: object
+                      groups:
+                        description: The names of groups this user is a part of.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      uid:
+                        description: |-
+                          A unique value that identifies this user across time. If this user is
+                          deleted and another user by the same name is added, they will have
+                          different UIDs.
+                        type: string
+                      username:
+                        description: The name that uniquely identifies this user among
+                          all active users.
+                        type: string
+                    type: object
+                type: object
+              lastPushedObjectState:
+                properties:
+                  lastPushedGitUser:
+                    type: string
+                  lastPushedObject:
+                    properties:
+                      group:
+                        type: string
+                      name:
+                        type: string
+                      resource:
+                        type: string
+                      version:
+                        type: string
+                    required:
+                    - group
+                    - name
+                    - resource
+                    - version
+                    type: object
+                  lastPushedObjectCommitHash:
+                    type: string
+                  lastPushedObjectGitPath:
+                    type: string
+                  lastPushedObjectGitRepo:
+                    type: string
+                  lastPushedObjectState:
+                    type: string
+                  lastPushedObjectTime:
+                    format: date-time
+                    type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: RemoteSyncer is the Schema for the remotesyncers API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: RemoteSyncerSpec defines the desired state of RemoteSyncer
+            properties:
+              bypassInterceptionSubjects:
+                items:
+                  description: |-
+                    Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,
+                    or a value for non-objects such as user and group names.
+                  properties:
+                    apiGroup:
+                      description: |-
+                        APIGroup holds the API group of the referenced subject.
+                        Defaults to "" for ServiceAccount subjects.
+                        Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                      type: string
+                    kind:
+                      description: |-
+                        Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount".
+                        If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                      type: string
+                    name:
+                      description: Name of the object being referenced.
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty
+                        the Authorizer should report an error.
+                      type: string
+                  required:
+                  - kind
+                  - name
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
+              caBundleSecretRef:
+                description: |-
+                  SecretReference represents a Secret Reference. It has enough information to retrieve secret
+                  in any namespace
+                properties:
+                  name:
+                    description: name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              defaultBlockAppliedMessage:
+                type: string
+              defaultBranch:
+                example: main
+                type: string
+              defaultRemoteUserRef:
+                description: |-
+                  ObjectReference contains enough information to let you inspect or modify the referred object.
+                  ---
+                  New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.
+                   1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.
+                   2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular
+                      restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".
+                      Those cannot be well described when embedded.
+                   3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.
+                   4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity
+                      during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple
+                      and the version of the actual struct is irrelevant.
+                   5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type
+                      will affect numerous schemas.  Don't make new APIs embed an underspecified API type they do not control.
+
+
+                  Instead of using this type, create a locally provided and used type that is well-focused on your reference.
+                  For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                      TODO: this design is not final and this field is subject to change in the future.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              defaultUnauthorizedUserMode:
+                default: Block
+                enum:
+                - Block
+                - UseDefaultUser
+                type: string
+              excludedFields:
+                items:
+                  type: string
+                type: array
+              excludedFieldsConfig:
+                description: |-
+                  ObjectReference contains enough information to let you inspect or modify the referred object.
+                  ---
+                  New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.
+                   1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.
+                   2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular
+                      restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".
+                      Those cannot be well described when embedded.
+                   3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.
+                   4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity
+                      during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple
+                      and the version of the actual struct is irrelevant.
+                   5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type
+                      will affect numerous schemas.  Don't make new APIs embed an underspecified API type they do not control.
+
+
+                  Instead of using this type, create a locally provided and used type that is well-focused on your reference.
+                  For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                      TODO: this design is not final and this field is subject to change in the future.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              insecureSkipTlsVerify:
+                type: boolean
+              processMode:
+                default: CommitApply
+                enum:
+                - CommitOnly
+                - CommitApply
+                type: string
+              pushMode:
+                default: SameBranch
+                enum:
+                - SameBranch
+                - MultipleBranch
+                - MergeRequest
+                type: string
+              remoteRepository:
+                example: https://git.example.com/my-repo.git
+                format: uri
+                type: string
+              rootPath:
+                type: string
+              scopedResources:
+                default: {}
+                properties:
+                  matchPolicy:
+                    description: MatchPolicyType specifies the type of match policy.
+                    type: string
+                  objectSelector:
+                    description: |-
+                      A label selector is a label query over a set of resources. The result of matchLabels and
+                      matchExpressions are ANDed. An empty label selector matches all objects. A null
+                      label selector matches no objects.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced during a strategic
+                                merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  rules:
+                    items:
+                      description: |-
+                        RuleWithOperations is a tuple of Operations and Resources. It is recommended to make
+                        sure that all the tuple expansions are valid.
+                      properties:
+                        apiGroups:
+                          description: |-
+                            APIGroups is the API groups the resources belong to. '*' is all groups.
+                            If '*' is present, the length of the slice must be one.
+                            Required.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        apiVersions:
+                          description: |-
+                            APIVersions is the API versions the resources belong to. '*' is all versions.
+                            If '*' is present, the length of the slice must be one.
+                            Required.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        operations:
+                          description: |-
+                            Operations is the operations the admission hook cares about - CREATE, UPDATE, DELETE, CONNECT or *
+                            for all of those operations and any future admission operations that are added.
+                            If '*' is present, the length of the slice must be one.
+                            Required.
+                          items:
+                            description: OperationType specifies an operation for
+                              a request.
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        resources:
+                          description: |-
+                            Resources is a list of resources this rule applies to.
+
+
+                            For example:
+                            'pods' means pods.
+                            'pods/log' means the log subresource of pods.
+                            '*' means all resources, but not subresources.
+                            'pods/*' means all subresources of pods.
+                            '*/scale' means all scale subresources.
+                            '*/*' means all resources and their subresources.
+
+
+                            If wildcard is present, the validation rule will ensure resources do not
+                            overlap with each other.
+
+
+                            Depending on the enclosing object, subresources might not be allowed.
+                            Required.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        scope:
+                          description: |-
+                            scope specifies the scope of this rule.
+                            Valid values are "Cluster", "Namespaced", and "*"
+                            "Cluster" means that only cluster-scoped resources will match this rule.
+                            Namespace API objects are cluster-scoped.
+                            "Namespaced" means that only namespaced resources will match this rule.
+                            "*" means that there are no scope restrictions.
+                            Subresources match the scope of their parent resource.
+                            Default is "*".
+                          type: string
+                      type: object
+                    type: array
+                type: object
+            required:
+            - defaultUnauthorizedUserMode
+            - processMode
+            - pushMode
+            - remoteRepository
+            - scopedResources
+            type: object
+          status:
+            properties:
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              lastBypassedObjectState:
+                properties:
+                  lastBypassObject:
+                    properties:
+                      group:
+                        type: string
+                      name:
+                        type: string
+                      resource:
+                        type: string
+                      version:
+                        type: string
+                    required:
+                    - group
+                    - name
+                    - resource
+                    - version
+                    type: object
+                  lastBypassObjectTime:
+                    format: date-time
+                    type: string
+                  lastBypassObjectUserInfo:
+                    description: |-
+                      UserInfo holds the information about the user needed to implement the
+                      user.Info interface.
+                    properties:
+                      extra:
+                        additionalProperties:
+                          description: ExtraValue masks the value so protobuf can
+                            generate
+                          items:
+                            type: string
+                          type: array
+                        description: Any additional information provided by the authenticator.
+                        type: object
+                      groups:
+                        description: The names of groups this user is a part of.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      uid:
+                        description: |-
+                          A unique value that identifies this user across time. If this user is
+                          deleted and another user by the same name is added, they will have
+                          different UIDs.
+                        type: string
+                      username:
+                        description: The name that uniquely identifies this user among
+                          all active users.
+                        type: string
+                    type: object
+                type: object
+              lastObservedObjectState:
+                properties:
+                  lastObservedObject:
+                    properties:
+                      group:
+                        type: string
+                      name:
+                        type: string
+                      resource:
+                        type: string
+                      version:
+                        type: string
+                    required:
+                    - group
+                    - name
+                    - resource
+                    - version
+                    type: object
+                  lastObservedObjectTime:
+                    format: date-time
+                    type: string
+                  lastObservedObjectUserInfo:
+                    description: |-
+                      UserInfo holds the information about the user needed to implement the
+                      user.Info interface.
+                    properties:
+                      extra:
+                        additionalProperties:
+                          description: ExtraValue masks the value so protobuf can
+                            generate
+                          items:
+                            type: string
+                          type: array
+                        description: Any additional information provided by the authenticator.
+                        type: object
+                      groups:
+                        description: The names of groups this user is a part of.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      uid:
+                        description: |-
+                          A unique value that identifies this user across time. If this user is
+                          deleted and another user by the same name is added, they will have
+                          different UIDs.
+                        type: string
+                      username:
+                        description: The name that uniquely identifies this user among
+                          all active users.
+                        type: string
+                    type: object
+                type: object
+              lastPushedObjectState:
+                properties:
+                  lastPushedGitUser:
+                    type: string
+                  lastPushedObject:
+                    properties:
+                      group:
+                        type: string
+                      name:
+                        type: string
+                      resource:
+                        type: string
+                      version:
+                        type: string
+                    required:
+                    - group
+                    - name
+                    - resource
+                    - version
+                    type: object
+                  lastPushedObjectCommitHash:
+                    type: string
+                  lastPushedObjectGitPath:
+                    type: string
+                  lastPushedObjectGitRepo:
+                    type: string
+                  lastPushedObjectState:
+                    type: string
+                  lastPushedObjectTime:
+                    format: date-time
+                    type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+{{- end }}

--- a/charts/0.2.1/templates/crd/syngit.io_remoteuser.yaml
+++ b/charts/0.2.1/templates/crd/syngit.io_remoteuser.yaml
@@ -1,0 +1,325 @@
+{{- if eq .Values.installCRD true }}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+    {{- if eq .Values.webhook.certmanager.enabled true }}
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/operator-webhook-cert
+    {{- end }}
+  name: remoteusers.syngit.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          namespace: {{ .Release.Namespace }}
+          name: webhook-crd-service
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1
+  group: syngit.io
+  names:
+    categories:
+    - syngit
+    kind: RemoteUser
+    listKind: RemoteUserList
+    plural: remoteusers
+    shortNames:
+    - ru
+    - rus
+    singular: remoteuser
+  scope: Namespaced
+  versions:
+  - deprecated: true
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: RemoteUser is the Schema for the remoteusers API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              associatedRemoteUserBinding:
+                type: boolean
+              email:
+                type: string
+              gitBaseDomainFQDN:
+                type: string
+              secretRef:
+                description: |-
+                  SecretReference represents a Secret Reference. It has enough information to retrieve secret
+                  in any namespace
+                properties:
+                  name:
+                    description: name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+            required:
+            - associatedRemoteUserBinding
+            - email
+            - gitBaseDomainFQDN
+            - secretRef
+            type: object
+          status:
+            properties:
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              connexionStatus:
+                properties:
+                  details:
+                    type: string
+                  status:
+                    type: string
+                type: object
+              gitUser:
+                type: string
+              lastAuthTime:
+                format: date-time
+                type: string
+              secretBoundStatus:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: RemoteUser is the Schema for the remoteusers API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              email:
+                type: string
+              gitBaseDomainFQDN:
+                type: string
+              secretRef:
+                description: |-
+                  SecretReference represents a Secret Reference. It has enough information to retrieve secret
+                  in any namespace
+                properties:
+                  name:
+                    description: name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+            required:
+            - email
+            - gitBaseDomainFQDN
+            - secretRef
+            type: object
+          status:
+            properties:
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              connexionStatus:
+                properties:
+                  details:
+                    type: string
+                  status:
+                    type: string
+                type: object
+              gitUser:
+                type: string
+              lastAuthTime:
+                format: date-time
+                type: string
+              secretBoundStatus:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+{{- end }}

--- a/charts/0.2.1/templates/crd/syngit.io_remoteuserbinding.yaml
+++ b/charts/0.2.1/templates/crd/syngit.io_remoteuserbinding.yaml
@@ -1,0 +1,370 @@
+{{- if eq .Values.installCRD true }}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+    {{- if eq .Values.webhook.certmanager.enabled true }}
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/operator-webhook-cert
+    {{- end }}
+  name: remoteuserbindings.syngit.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          namespace: {{ .Release.Namespace }}
+          name: webhook-crd-service
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1
+  group: syngit.io
+  names:
+    categories:
+    - syngit
+    kind: RemoteUserBinding
+    listKind: RemoteUserBindingList
+    plural: remoteuserbindings
+    shortNames:
+    - rub
+    - rubs
+    singular: remoteuserbinding
+  scope: Namespaced
+  versions:
+  - deprecated: true
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: RemoteUserBinding is the Schema for the remoteuserbindings API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              remoteRefs:
+                items:
+                  description: |-
+                    ObjectReference contains enough information to let you inspect or modify the referred object.
+                    ---
+                    New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.
+                     1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.
+                     2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular
+                        restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".
+                        Those cannot be well described when embedded.
+                     3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.
+                     4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity
+                        during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple
+                        and the version of the actual struct is irrelevant.
+                     5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type
+                        will affect numerous schemas.  Don't make new APIs embed an underspecified API type they do not control.
+
+
+                    Instead of using this type, create a locally provided and used type that is well-focused on your reference.
+                    For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: |-
+                        If referring to a piece of an object instead of an entire object, this string
+                        should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within a pod, this would take on a value like:
+                        "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]" (container with
+                        index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                        referencing a part of an object.
+                        TODO: this design is not final and this field is subject to change in the future.
+                      type: string
+                    kind:
+                      description: |-
+                        Kind of the referent.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                      type: string
+                    name:
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                      type: string
+                    resourceVersion:
+                      description: |-
+                        Specific resourceVersion to which this reference is made, if any.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                      type: string
+                    uid:
+                      description: |-
+                        UID of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
+              subject:
+                description: |-
+                  Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,
+                  or a value for non-objects such as user and group names.
+                properties:
+                  apiGroup:
+                    description: |-
+                      APIGroup holds the API group of the referenced subject.
+                      Defaults to "" for ServiceAccount subjects.
+                      Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount".
+                      If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                    type: string
+                  name:
+                    description: Name of the object being referenced.
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty
+                      the Authorizer should report an error.
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+            required:
+            - remoteRefs
+            - subject
+            type: object
+          status:
+            properties:
+              gitUserHosts:
+                items:
+                  properties:
+                    gitFQDN:
+                      type: string
+                    lastUsedTime:
+                      format: date-time
+                      type: string
+                    remoteUserUsed:
+                      type: string
+                    secretRef:
+                      description: |-
+                        SecretReference represents a Secret Reference. It has enough information to retrieve secret
+                        in any namespace
+                      properties:
+                        name:
+                          description: name is unique within a namespace to reference
+                            a secret resource.
+                          type: string
+                        namespace:
+                          description: namespace defines the space within which the
+                            secret name must be unique.
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    state:
+                      type: string
+                  required:
+                  - secretRef
+                  type: object
+                type: array
+              lastUsedTime:
+                format: date-time
+                type: string
+              state:
+                type: string
+              userKubernetesID:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: RemoteUserBinding is the Schema for the remoteuserbindings API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              remoteRefs:
+                items:
+                  description: |-
+                    ObjectReference contains enough information to let you inspect or modify the referred object.
+                    ---
+                    New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.
+                     1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.
+                     2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular
+                        restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".
+                        Those cannot be well described when embedded.
+                     3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.
+                     4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity
+                        during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple
+                        and the version of the actual struct is irrelevant.
+                     5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type
+                        will affect numerous schemas.  Don't make new APIs embed an underspecified API type they do not control.
+
+
+                    Instead of using this type, create a locally provided and used type that is well-focused on your reference.
+                    For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: |-
+                        If referring to a piece of an object instead of an entire object, this string
+                        should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within a pod, this would take on a value like:
+                        "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]" (container with
+                        index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                        referencing a part of an object.
+                        TODO: this design is not final and this field is subject to change in the future.
+                      type: string
+                    kind:
+                      description: |-
+                        Kind of the referent.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                      type: string
+                    name:
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                      type: string
+                    resourceVersion:
+                      description: |-
+                        Specific resourceVersion to which this reference is made, if any.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                      type: string
+                    uid:
+                      description: |-
+                        UID of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
+              subject:
+                description: |-
+                  Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,
+                  or a value for non-objects such as user and group names.
+                properties:
+                  apiGroup:
+                    description: |-
+                      APIGroup holds the API group of the referenced subject.
+                      Defaults to "" for ServiceAccount subjects.
+                      Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount".
+                      If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                    type: string
+                  name:
+                    description: Name of the object being referenced.
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty
+                      the Authorizer should report an error.
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+            required:
+            - remoteRefs
+            - subject
+            type: object
+          status:
+            properties:
+              gitUserHosts:
+                items:
+                  properties:
+                    gitFQDN:
+                      type: string
+                    lastUsedTime:
+                      format: date-time
+                      type: string
+                    remoteUserUsed:
+                      type: string
+                    secretRef:
+                      description: |-
+                        SecretReference represents a Secret Reference. It has enough information to retrieve secret
+                        in any namespace
+                      properties:
+                        name:
+                          description: name is unique within a namespace to reference
+                            a secret resource.
+                          type: string
+                        namespace:
+                          description: namespace defines the space within which the
+                            secret name must be unique.
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    state:
+                      type: string
+                  required:
+                  - secretRef
+                  type: object
+                type: array
+              lastUsedTime:
+                format: date-time
+                type: string
+              state:
+                type: string
+              userKubernetesID:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+{{- end }}

--- a/charts/0.2.1/templates/crd/syngit.syngit.io_remotesyncer.yaml
+++ b/charts/0.2.1/templates/crd/syngit.syngit.io_remotesyncer.yaml
@@ -1,0 +1,1189 @@
+{{- if eq .Values.installCRD true }}
+{{- if .Release.IsUpgrade -}}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+    {{- if eq .Values.webhook.certmanager.enabled true }}
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/operator-webhook-cert
+    {{- end }}
+  name: remotesyncers.syngit.syngit.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          namespace: {{ .Release.Namespace }}
+          name: webhook-crd-service
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1
+  group: syngit.syngit.io
+  names:
+    categories:
+    - syngit
+    kind: RemoteSyncer
+    listKind: RemoteSyncerList
+    plural: remotesyncers
+    shortNames:
+    - rs
+    - rss
+    singular: remotesyncer
+  scope: Namespaced
+  versions:
+  - deprecated: true
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: RemoteSyncer is the Schema for the remotesyncers API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: RemoteSyncerSpec defines the desired state of RemoteSyncer
+            properties:
+              bypassInterceptionSubjects:
+                items:
+                  description: |-
+                    Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,
+                    or a value for non-objects such as user and group names.
+                  properties:
+                    apiGroup:
+                      description: |-
+                        APIGroup holds the API group of the referenced subject.
+                        Defaults to "" for ServiceAccount subjects.
+                        Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                      type: string
+                    kind:
+                      description: |-
+                        Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount".
+                        If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                      type: string
+                    name:
+                      description: Name of the object being referenced.
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty
+                        the Authorizer should report an error.
+                      type: string
+                  required:
+                  - kind
+                  - name
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
+              caBundle:
+                description: |-
+                  SecretReference represents a Secret Reference. It has enough information to retrieve secret
+                  in any namespace
+                properties:
+                  name:
+                    description: name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              defaultBlockAppliedMessage:
+                type: string
+              defaultBranch:
+                type: string
+              defaultUnauthorizedUserMode:
+                type: string
+              defaultUser:
+                description: |-
+                  ObjectReference contains enough information to let you inspect or modify the referred object.
+                  ---
+                  New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.
+                   1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.
+                   2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular
+                      restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".
+                      Those cannot be well described when embedded.
+                   3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.
+                   4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity
+                      during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple
+                      and the version of the actual struct is irrelevant.
+                   5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type
+                      will affect numerous schemas.  Don't make new APIs embed an underspecified API type they do not control.
+
+
+                  Instead of using this type, create a locally provided and used type that is well-focused on your reference.
+                  For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                      TODO: this design is not final and this field is subject to change in the future.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              excludedFields:
+                items:
+                  type: string
+                type: array
+              excludedFieldsConfig:
+                description: |-
+                  ObjectReference contains enough information to let you inspect or modify the referred object.
+                  ---
+                  New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.
+                   1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.
+                   2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular
+                      restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".
+                      Those cannot be well described when embedded.
+                   3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.
+                   4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity
+                      during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple
+                      and the version of the actual struct is irrelevant.
+                   5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type
+                      will affect numerous schemas.  Don't make new APIs embed an underspecified API type they do not control.
+
+
+                  Instead of using this type, create a locally provided and used type that is well-focused on your reference.
+                  For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                      TODO: this design is not final and this field is subject to change in the future.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              insecureSkipTlsVerify:
+                type: boolean
+              processMode:
+                type: string
+              pushMode:
+                type: string
+              remoteRepository:
+                format: uri
+                type: string
+              rootPath:
+                type: string
+              scopedResources:
+                properties:
+                  matchPolicy:
+                    description: MatchPolicyType specifies the type of match policy.
+                    type: string
+                  objectSelector:
+                    description: |-
+                      A label selector is a label query over a set of resources. The result of matchLabels and
+                      matchExpressions are ANDed. An empty label selector matches all objects. A null
+                      label selector matches no objects.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced during a strategic
+                                merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  rules:
+                    items:
+                      description: |-
+                        RuleWithOperations is a tuple of Operations and Resources. It is recommended to make
+                        sure that all the tuple expansions are valid.
+                      properties:
+                        apiGroups:
+                          description: |-
+                            APIGroups is the API groups the resources belong to. '*' is all groups.
+                            If '*' is present, the length of the slice must be one.
+                            Required.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        apiVersions:
+                          description: |-
+                            APIVersions is the API versions the resources belong to. '*' is all versions.
+                            If '*' is present, the length of the slice must be one.
+                            Required.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        operations:
+                          description: |-
+                            Operations is the operations the admission hook cares about - CREATE, UPDATE, DELETE, CONNECT or *
+                            for all of those operations and any future admission operations that are added.
+                            If '*' is present, the length of the slice must be one.
+                            Required.
+                          items:
+                            description: OperationType specifies an operation for
+                              a request.
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        resources:
+                          description: |-
+                            Resources is a list of resources this rule applies to.
+
+
+                            For example:
+                            'pods' means pods.
+                            'pods/log' means the log subresource of pods.
+                            '*' means all resources, but not subresources.
+                            'pods/*' means all subresources of pods.
+                            '*/scale' means all scale subresources.
+                            '*/*' means all resources and their subresources.
+
+
+                            If wildcard is present, the validation rule will ensure resources do not
+                            overlap with each other.
+
+
+                            Depending on the enclosing object, subresources might not be allowed.
+                            Required.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        scope:
+                          description: |-
+                            scope specifies the scope of this rule.
+                            Valid values are "Cluster", "Namespaced", and "*"
+                            "Cluster" means that only cluster-scoped resources will match this rule.
+                            Namespace API objects are cluster-scoped.
+                            "Namespaced" means that only namespaced resources will match this rule.
+                            "*" means that there are no scope restrictions.
+                            Subresources match the scope of their parent resource.
+                            Default is "*".
+                          type: string
+                      type: object
+                    type: array
+                type: object
+            required:
+            - defaultUnauthorizedUserMode
+            - processMode
+            - pushMode
+            - remoteRepository
+            type: object
+          status:
+            properties:
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              lastBypassedObjectState:
+                properties:
+                  lastBypassObject:
+                    properties:
+                      group:
+                        type: string
+                      name:
+                        type: string
+                      resource:
+                        type: string
+                      version:
+                        type: string
+                    required:
+                    - group
+                    - name
+                    - resource
+                    - version
+                    type: object
+                  lastBypassObjectTime:
+                    format: date-time
+                    type: string
+                  lastBypassObjectUserInfo:
+                    description: |-
+                      UserInfo holds the information about the user needed to implement the
+                      user.Info interface.
+                    properties:
+                      extra:
+                        additionalProperties:
+                          description: ExtraValue masks the value so protobuf can
+                            generate
+                          items:
+                            type: string
+                          type: array
+                        description: Any additional information provided by the authenticator.
+                        type: object
+                      groups:
+                        description: The names of groups this user is a part of.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      uid:
+                        description: |-
+                          A unique value that identifies this user across time. If this user is
+                          deleted and another user by the same name is added, they will have
+                          different UIDs.
+                        type: string
+                      username:
+                        description: The name that uniquely identifies this user among
+                          all active users.
+                        type: string
+                    type: object
+                type: object
+              lastObservedObjectState:
+                properties:
+                  lastObservedObject:
+                    properties:
+                      group:
+                        type: string
+                      name:
+                        type: string
+                      resource:
+                        type: string
+                      version:
+                        type: string
+                    required:
+                    - group
+                    - name
+                    - resource
+                    - version
+                    type: object
+                  lastObservedObjectTime:
+                    format: date-time
+                    type: string
+                  lastObservedObjectUserInfo:
+                    description: |-
+                      UserInfo holds the information about the user needed to implement the
+                      user.Info interface.
+                    properties:
+                      extra:
+                        additionalProperties:
+                          description: ExtraValue masks the value so protobuf can
+                            generate
+                          items:
+                            type: string
+                          type: array
+                        description: Any additional information provided by the authenticator.
+                        type: object
+                      groups:
+                        description: The names of groups this user is a part of.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      uid:
+                        description: |-
+                          A unique value that identifies this user across time. If this user is
+                          deleted and another user by the same name is added, they will have
+                          different UIDs.
+                        type: string
+                      username:
+                        description: The name that uniquely identifies this user among
+                          all active users.
+                        type: string
+                    type: object
+                type: object
+              lastPushedObjectState:
+                properties:
+                  lastPushedGitUser:
+                    type: string
+                  lastPushedObject:
+                    properties:
+                      group:
+                        type: string
+                      name:
+                        type: string
+                      resource:
+                        type: string
+                      version:
+                        type: string
+                    required:
+                    - group
+                    - name
+                    - resource
+                    - version
+                    type: object
+                  lastPushedObjectCommitHash:
+                    type: string
+                  lastPushedObjectGitPath:
+                    type: string
+                  lastPushedObjectGitRepo:
+                    type: string
+                  lastPushedObjectState:
+                    type: string
+                  lastPushedObjectTime:
+                    format: date-time
+                    type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: RemoteSyncer is the Schema for the remotesyncers API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: RemoteSyncerSpec defines the desired state of RemoteSyncer
+            properties:
+              bypassInterceptionSubjects:
+                items:
+                  description: |-
+                    Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,
+                    or a value for non-objects such as user and group names.
+                  properties:
+                    apiGroup:
+                      description: |-
+                        APIGroup holds the API group of the referenced subject.
+                        Defaults to "" for ServiceAccount subjects.
+                        Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                      type: string
+                    kind:
+                      description: |-
+                        Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount".
+                        If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                      type: string
+                    name:
+                      description: Name of the object being referenced.
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty
+                        the Authorizer should report an error.
+                      type: string
+                  required:
+                  - kind
+                  - name
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
+              caBundleSecretRef:
+                description: |-
+                  SecretReference represents a Secret Reference. It has enough information to retrieve secret
+                  in any namespace
+                properties:
+                  name:
+                    description: name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              defaultBlockAppliedMessage:
+                type: string
+              defaultBranch:
+                example: main
+                type: string
+              defaultRemoteUserRef:
+                description: |-
+                  ObjectReference contains enough information to let you inspect or modify the referred object.
+                  ---
+                  New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.
+                   1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.
+                   2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular
+                      restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".
+                      Those cannot be well described when embedded.
+                   3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.
+                   4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity
+                      during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple
+                      and the version of the actual struct is irrelevant.
+                   5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type
+                      will affect numerous schemas.  Don't make new APIs embed an underspecified API type they do not control.
+
+
+                  Instead of using this type, create a locally provided and used type that is well-focused on your reference.
+                  For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                      TODO: this design is not final and this field is subject to change in the future.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              defaultUnauthorizedUserMode:
+                default: Block
+                enum:
+                - Block
+                - UseDefaultUser
+                type: string
+              excludedFields:
+                items:
+                  type: string
+                type: array
+              excludedFieldsConfig:
+                description: |-
+                  ObjectReference contains enough information to let you inspect or modify the referred object.
+                  ---
+                  New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.
+                   1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.
+                   2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular
+                      restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".
+                      Those cannot be well described when embedded.
+                   3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.
+                   4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity
+                      during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple
+                      and the version of the actual struct is irrelevant.
+                   5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type
+                      will affect numerous schemas.  Don't make new APIs embed an underspecified API type they do not control.
+
+
+                  Instead of using this type, create a locally provided and used type that is well-focused on your reference.
+                  For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                      TODO: this design is not final and this field is subject to change in the future.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              insecureSkipTlsVerify:
+                type: boolean
+              processMode:
+                default: CommitApply
+                enum:
+                - CommitOnly
+                - CommitApply
+                type: string
+              pushMode:
+                default: SameBranch
+                enum:
+                - SameBranch
+                - MultipleBranch
+                - MergeRequest
+                type: string
+              remoteRepository:
+                example: https://git.example.com/my-repo.git
+                format: uri
+                type: string
+              rootPath:
+                type: string
+              scopedResources:
+                default: {}
+                properties:
+                  matchPolicy:
+                    description: MatchPolicyType specifies the type of match policy.
+                    type: string
+                  objectSelector:
+                    description: |-
+                      A label selector is a label query over a set of resources. The result of matchLabels and
+                      matchExpressions are ANDed. An empty label selector matches all objects. A null
+                      label selector matches no objects.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced during a strategic
+                                merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  rules:
+                    items:
+                      description: |-
+                        RuleWithOperations is a tuple of Operations and Resources. It is recommended to make
+                        sure that all the tuple expansions are valid.
+                      properties:
+                        apiGroups:
+                          description: |-
+                            APIGroups is the API groups the resources belong to. '*' is all groups.
+                            If '*' is present, the length of the slice must be one.
+                            Required.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        apiVersions:
+                          description: |-
+                            APIVersions is the API versions the resources belong to. '*' is all versions.
+                            If '*' is present, the length of the slice must be one.
+                            Required.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        operations:
+                          description: |-
+                            Operations is the operations the admission hook cares about - CREATE, UPDATE, DELETE, CONNECT or *
+                            for all of those operations and any future admission operations that are added.
+                            If '*' is present, the length of the slice must be one.
+                            Required.
+                          items:
+                            description: OperationType specifies an operation for
+                              a request.
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        resources:
+                          description: |-
+                            Resources is a list of resources this rule applies to.
+
+
+                            For example:
+                            'pods' means pods.
+                            'pods/log' means the log subresource of pods.
+                            '*' means all resources, but not subresources.
+                            'pods/*' means all subresources of pods.
+                            '*/scale' means all scale subresources.
+                            '*/*' means all resources and their subresources.
+
+
+                            If wildcard is present, the validation rule will ensure resources do not
+                            overlap with each other.
+
+
+                            Depending on the enclosing object, subresources might not be allowed.
+                            Required.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        scope:
+                          description: |-
+                            scope specifies the scope of this rule.
+                            Valid values are "Cluster", "Namespaced", and "*"
+                            "Cluster" means that only cluster-scoped resources will match this rule.
+                            Namespace API objects are cluster-scoped.
+                            "Namespaced" means that only namespaced resources will match this rule.
+                            "*" means that there are no scope restrictions.
+                            Subresources match the scope of their parent resource.
+                            Default is "*".
+                          type: string
+                      type: object
+                    type: array
+                type: object
+            required:
+            - defaultUnauthorizedUserMode
+            - processMode
+            - pushMode
+            - remoteRepository
+            - scopedResources
+            type: object
+          status:
+            properties:
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              lastBypassedObjectState:
+                properties:
+                  lastBypassObject:
+                    properties:
+                      group:
+                        type: string
+                      name:
+                        type: string
+                      resource:
+                        type: string
+                      version:
+                        type: string
+                    required:
+                    - group
+                    - name
+                    - resource
+                    - version
+                    type: object
+                  lastBypassObjectTime:
+                    format: date-time
+                    type: string
+                  lastBypassObjectUserInfo:
+                    description: |-
+                      UserInfo holds the information about the user needed to implement the
+                      user.Info interface.
+                    properties:
+                      extra:
+                        additionalProperties:
+                          description: ExtraValue masks the value so protobuf can
+                            generate
+                          items:
+                            type: string
+                          type: array
+                        description: Any additional information provided by the authenticator.
+                        type: object
+                      groups:
+                        description: The names of groups this user is a part of.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      uid:
+                        description: |-
+                          A unique value that identifies this user across time. If this user is
+                          deleted and another user by the same name is added, they will have
+                          different UIDs.
+                        type: string
+                      username:
+                        description: The name that uniquely identifies this user among
+                          all active users.
+                        type: string
+                    type: object
+                type: object
+              lastObservedObjectState:
+                properties:
+                  lastObservedObject:
+                    properties:
+                      group:
+                        type: string
+                      name:
+                        type: string
+                      resource:
+                        type: string
+                      version:
+                        type: string
+                    required:
+                    - group
+                    - name
+                    - resource
+                    - version
+                    type: object
+                  lastObservedObjectTime:
+                    format: date-time
+                    type: string
+                  lastObservedObjectUserInfo:
+                    description: |-
+                      UserInfo holds the information about the user needed to implement the
+                      user.Info interface.
+                    properties:
+                      extra:
+                        additionalProperties:
+                          description: ExtraValue masks the value so protobuf can
+                            generate
+                          items:
+                            type: string
+                          type: array
+                        description: Any additional information provided by the authenticator.
+                        type: object
+                      groups:
+                        description: The names of groups this user is a part of.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      uid:
+                        description: |-
+                          A unique value that identifies this user across time. If this user is
+                          deleted and another user by the same name is added, they will have
+                          different UIDs.
+                        type: string
+                      username:
+                        description: The name that uniquely identifies this user among
+                          all active users.
+                        type: string
+                    type: object
+                type: object
+              lastPushedObjectState:
+                properties:
+                  lastPushedGitUser:
+                    type: string
+                  lastPushedObject:
+                    properties:
+                      group:
+                        type: string
+                      name:
+                        type: string
+                      resource:
+                        type: string
+                      version:
+                        type: string
+                    required:
+                    - group
+                    - name
+                    - resource
+                    - version
+                    type: object
+                  lastPushedObjectCommitHash:
+                    type: string
+                  lastPushedObjectGitPath:
+                    type: string
+                  lastPushedObjectGitRepo:
+                    type: string
+                  lastPushedObjectState:
+                    type: string
+                  lastPushedObjectTime:
+                    format: date-time
+                    type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+{{- end }}
+{{- end }}

--- a/charts/0.2.1/templates/crd/syngit.syngit.io_remoteuser.yaml
+++ b/charts/0.2.1/templates/crd/syngit.syngit.io_remoteuser.yaml
@@ -1,0 +1,327 @@
+{{- if eq .Values.installCRD true }}
+{{- if .Release.IsUpgrade -}}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+    {{- if eq .Values.webhook.certmanager.enabled true }}
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/operator-webhook-cert
+    {{- end }}
+  name: remoteusers.syngit.syngit.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          namespace: {{ .Release.Namespace }}
+          name: webhook-crd-service
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1
+  group: syngit.syngit.io
+  names:
+    categories:
+    - syngit
+    kind: RemoteUser
+    listKind: RemoteUserList
+    plural: remoteusers
+    shortNames:
+    - ru
+    - rus
+    singular: remoteuser
+  scope: Namespaced
+  versions:
+  - deprecated: true
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: RemoteUser is the Schema for the remoteusers API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              associatedRemoteUserBinding:
+                type: boolean
+              email:
+                type: string
+              gitBaseDomainFQDN:
+                type: string
+              secretRef:
+                description: |-
+                  SecretReference represents a Secret Reference. It has enough information to retrieve secret
+                  in any namespace
+                properties:
+                  name:
+                    description: name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+            required:
+            - associatedRemoteUserBinding
+            - email
+            - gitBaseDomainFQDN
+            - secretRef
+            type: object
+          status:
+            properties:
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              connexionStatus:
+                properties:
+                  details:
+                    type: string
+                  status:
+                    type: string
+                type: object
+              gitUser:
+                type: string
+              lastAuthTime:
+                format: date-time
+                type: string
+              secretBoundStatus:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: RemoteUser is the Schema for the remoteusers API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              email:
+                type: string
+              gitBaseDomainFQDN:
+                type: string
+              secretRef:
+                description: |-
+                  SecretReference represents a Secret Reference. It has enough information to retrieve secret
+                  in any namespace
+                properties:
+                  name:
+                    description: name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+            required:
+            - email
+            - gitBaseDomainFQDN
+            - secretRef
+            type: object
+          status:
+            properties:
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              connexionStatus:
+                properties:
+                  details:
+                    type: string
+                  status:
+                    type: string
+                type: object
+              gitUser:
+                type: string
+              lastAuthTime:
+                format: date-time
+                type: string
+              secretBoundStatus:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+{{- end }}
+{{- end }}

--- a/charts/0.2.1/templates/crd/syngit.syngit.io_remoteuserbinding.yaml
+++ b/charts/0.2.1/templates/crd/syngit.syngit.io_remoteuserbinding.yaml
@@ -1,0 +1,372 @@
+{{- if eq .Values.installCRD true }}
+{{- if .Release.IsUpgrade -}}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+    {{- if eq .Values.webhook.certmanager.enabled true }}
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/operator-webhook-cert
+    {{- end }}
+  name: remoteuserbindings.syngit.syngit.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          namespace: {{ .Release.Namespace }}
+          name: webhook-crd-service
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1
+  group: syngit.syngit.io
+  names:
+    categories:
+    - syngit
+    kind: RemoteUserBinding
+    listKind: RemoteUserBindingList
+    plural: remoteuserbindings
+    shortNames:
+    - rub
+    - rubs
+    singular: remoteuserbinding
+  scope: Namespaced
+  versions:
+  - deprecated: true
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: RemoteUserBinding is the Schema for the remoteuserbindings API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              remoteRefs:
+                items:
+                  description: |-
+                    ObjectReference contains enough information to let you inspect or modify the referred object.
+                    ---
+                    New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.
+                     1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.
+                     2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular
+                        restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".
+                        Those cannot be well described when embedded.
+                     3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.
+                     4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity
+                        during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple
+                        and the version of the actual struct is irrelevant.
+                     5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type
+                        will affect numerous schemas.  Don't make new APIs embed an underspecified API type they do not control.
+
+
+                    Instead of using this type, create a locally provided and used type that is well-focused on your reference.
+                    For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: |-
+                        If referring to a piece of an object instead of an entire object, this string
+                        should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within a pod, this would take on a value like:
+                        "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]" (container with
+                        index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                        referencing a part of an object.
+                        TODO: this design is not final and this field is subject to change in the future.
+                      type: string
+                    kind:
+                      description: |-
+                        Kind of the referent.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                      type: string
+                    name:
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                      type: string
+                    resourceVersion:
+                      description: |-
+                        Specific resourceVersion to which this reference is made, if any.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                      type: string
+                    uid:
+                      description: |-
+                        UID of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
+              subject:
+                description: |-
+                  Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,
+                  or a value for non-objects such as user and group names.
+                properties:
+                  apiGroup:
+                    description: |-
+                      APIGroup holds the API group of the referenced subject.
+                      Defaults to "" for ServiceAccount subjects.
+                      Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount".
+                      If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                    type: string
+                  name:
+                    description: Name of the object being referenced.
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty
+                      the Authorizer should report an error.
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+            required:
+            - remoteRefs
+            - subject
+            type: object
+          status:
+            properties:
+              gitUserHosts:
+                items:
+                  properties:
+                    gitFQDN:
+                      type: string
+                    lastUsedTime:
+                      format: date-time
+                      type: string
+                    remoteUserUsed:
+                      type: string
+                    secretRef:
+                      description: |-
+                        SecretReference represents a Secret Reference. It has enough information to retrieve secret
+                        in any namespace
+                      properties:
+                        name:
+                          description: name is unique within a namespace to reference
+                            a secret resource.
+                          type: string
+                        namespace:
+                          description: namespace defines the space within which the
+                            secret name must be unique.
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    state:
+                      type: string
+                  required:
+                  - secretRef
+                  type: object
+                type: array
+              lastUsedTime:
+                format: date-time
+                type: string
+              state:
+                type: string
+              userKubernetesID:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: RemoteUserBinding is the Schema for the remoteuserbindings API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              remoteRefs:
+                items:
+                  description: |-
+                    ObjectReference contains enough information to let you inspect or modify the referred object.
+                    ---
+                    New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.
+                     1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.
+                     2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular
+                        restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".
+                        Those cannot be well described when embedded.
+                     3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.
+                     4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity
+                        during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple
+                        and the version of the actual struct is irrelevant.
+                     5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type
+                        will affect numerous schemas.  Don't make new APIs embed an underspecified API type they do not control.
+
+
+                    Instead of using this type, create a locally provided and used type that is well-focused on your reference.
+                    For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: |-
+                        If referring to a piece of an object instead of an entire object, this string
+                        should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within a pod, this would take on a value like:
+                        "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]" (container with
+                        index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                        referencing a part of an object.
+                        TODO: this design is not final and this field is subject to change in the future.
+                      type: string
+                    kind:
+                      description: |-
+                        Kind of the referent.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                      type: string
+                    name:
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                      type: string
+                    resourceVersion:
+                      description: |-
+                        Specific resourceVersion to which this reference is made, if any.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                      type: string
+                    uid:
+                      description: |-
+                        UID of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
+              subject:
+                description: |-
+                  Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,
+                  or a value for non-objects such as user and group names.
+                properties:
+                  apiGroup:
+                    description: |-
+                      APIGroup holds the API group of the referenced subject.
+                      Defaults to "" for ServiceAccount subjects.
+                      Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount".
+                      If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                    type: string
+                  name:
+                    description: Name of the object being referenced.
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty
+                      the Authorizer should report an error.
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+            required:
+            - remoteRefs
+            - subject
+            type: object
+          status:
+            properties:
+              gitUserHosts:
+                items:
+                  properties:
+                    gitFQDN:
+                      type: string
+                    lastUsedTime:
+                      format: date-time
+                      type: string
+                    remoteUserUsed:
+                      type: string
+                    secretRef:
+                      description: |-
+                        SecretReference represents a Secret Reference. It has enough information to retrieve secret
+                        in any namespace
+                      properties:
+                        name:
+                          description: name is unique within a namespace to reference
+                            a secret resource.
+                          type: string
+                        namespace:
+                          description: namespace defines the space within which the
+                            secret name must be unique.
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    state:
+                      type: string
+                  required:
+                  - secretRef
+                  type: object
+                type: array
+              lastUsedTime:
+                format: date-time
+                type: string
+              state:
+                type: string
+              userKubernetesID:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+{{- end }}
+{{- end }}

--- a/charts/0.2.1/templates/monitoring/monitor.yaml
+++ b/charts/0.2.1/templates/monitoring/monitor.yaml
@@ -1,0 +1,25 @@
+{{- if eq .Values.monitoring.enabled true }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    control-plane: controller-manager
+    app.kubernetes.io/name: servicemonitor
+    app.kubernetes.io/instance: controller-manager-metrics-monitor
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  name: {{ .Release.Name }}-controller-manager-metrics-monitor
+spec:
+  endpoints:
+    - path: /metrics
+      port: https
+      scheme: https
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        insecureSkipVerify: true
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+{{- end }}

--- a/charts/0.2.1/templates/providers/github-controller.yaml
+++ b/charts/0.2.1/templates/providers/github-controller.yaml
@@ -1,0 +1,92 @@
+{{- if eq .Values.providers.github.enabled true }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: provider-github
+  labels:
+    control-plane: provider-github
+    app.kubernetes.io/name: deployment
+    app.kubernetes.io/instance: provider-github
+    app.kubernetes.io/component: manager
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+spec:
+  selector:
+    matchLabels:
+      control-plane: provider-github
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        control-plane: provider-github
+    spec:
+      {{- if .Values.providers.github.controller.imagePullSecrets }}
+      imagePullSecrets:
+        {{ toYaml .Values.providers.github.controller.imagePullSecrets | nindent 8 }}
+      {{- end }}
+      containers:
+      {{- if eq .Values.providers.github.controller.metrics.enabled true }}
+      - name: kube-rbac-proxy
+        securityContext: {{ toYaml .Values.providers.github.controller.rbacProxy.securityContext | nindent 10 }}
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
+        args:
+        - "--secure-listen-address=0.0.0.0:8443"
+        - "--upstream={{ .Values.providers.github.rbacProxy.controller.upstreamAddress }}"
+        - "--logtostderr=true"
+        - "--v=0"
+        ports:
+        - containerPort: 8443
+          protocol: TCP
+          name: https
+        resources: {{ toYaml .Values.providers.github.rbacProxy.controller.resources | nindent 10 }}
+      {{- end }}
+      - command:
+        - /manager
+        {{- if .Values.providers.github.controller.imagePullPolicy }}
+        imagePullPolicy: {{ .Values.providers.github.controller.imagePullPolicy }}
+        {{- end }}
+        args:
+        - "--leader-elect"
+        {{- if eq .Values.providers.github.controller.metrics.enabled true }}
+        - "--health-probe-bind-address=:8081"
+        - "--metrics-bind-address={{ .Values.providers.github.controller.metrics.bindAddress }}"
+        {{- end }}
+        image: ghcr.io/syngit-org/syngit-provider-github:v0.0.1
+        env:
+        - name: MANAGER_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: DYNAMIC_WEBHOOK_NAME
+          value: {{ .Values.providers.github.controller.dynamicWebhookName }}
+        name: manager
+        securityContext: {{ toYaml .Values.providers.github.controller.securityContext | nindent 10 }}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources: {{ toYaml .Values.providers.github.controller.resources | nindent 10 }}
+        ports:
+        - containerPort: 9443
+          name: wbhk-crd-srv
+          protocol: TCP
+        - containerPort: 9444
+          name: wbhk-pusher-srv
+          protocol: TCP
+      serviceAccountName: {{ .Release.Name }}-providers-controller-manager
+      terminationGracePeriodSeconds: 10
+      {{- if .Values.providers.github.controller.tolerations }}
+      tolerations: {{ toYaml .Values.providers.github.controller.tolerations | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/0.2.1/templates/providers/gitlab-controller.yaml
+++ b/charts/0.2.1/templates/providers/gitlab-controller.yaml
@@ -1,0 +1,92 @@
+{{- if eq .Values.providers.gitlab.enabled true }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: provider-gitlab
+  labels:
+    control-plane: provider-gitlab
+    app.kubernetes.io/name: deployment
+    app.kubernetes.io/instance: provider-gitlab
+    app.kubernetes.io/component: manager
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+spec:
+  selector:
+    matchLabels:
+      control-plane: provider-gitlab
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        control-plane: provider-gitlab
+    spec:
+      {{- if .Values.providers.gitlab.controller.imagePullSecrets }}
+      imagePullSecrets:
+        {{ toYaml .Values.providers.gitlab.controller.imagePullSecrets | nindent 8 }}
+      {{- end }}
+      containers:
+      {{- if eq .Values.providers.gitlab.controller.metrics.enabled true }}
+      - name: kube-rbac-proxy
+        securityContext: {{ toYaml .Values.providers.gitlab.rbacProxy.securityContext | nindent 10 }}
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
+        args:
+        - "--secure-listen-address=0.0.0.0:8443"
+        - "--upstream={{ .Values.providers.gitlab.rbacProxy.upstreamAddress }}"
+        - "--logtostderr=true"
+        - "--v=0"
+        ports:
+        - containerPort: 8443
+          protocol: TCP
+          name: https
+        resources: {{ toYaml .Values.providers.gitlab.controller.rbacProxy.resources | nindent 10 }}
+      {{- end }}
+      - command:
+        - /manager
+        {{- if .Values.providers.gitlab.controller.imagePullPolicy }}
+        imagePullPolicy: {{ .Values.providers.gitlab.controller.imagePullPolicy }}
+        {{- end }}
+        args:
+        - "--leader-elect"
+        {{- if eq .Values.providers.gitlab.controller.metrics.enabled true }}
+        - "--health-probe-bind-address=:8081"
+        - "--metrics-bind-address={{ .Values.providers.gitlab.controller.metrics.bindAddress }}"
+        {{- end }}
+        image: ghcr.io/syngit-org/syngit-provider-gitlab:v0.0.1
+        env:
+        - name: MANAGER_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: DYNAMIC_WEBHOOK_NAME
+          value: {{ .Values.providers.gitlab.controller.dynamicWebhookName }}
+        name: manager
+        securityContext: {{ toYaml .Values.providers.gitlab.securityContext | nindent 10 }}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources: {{ toYaml .Values.providers.gitlab.controller.resources | nindent 10 }}
+        ports:
+        - containerPort: 9443
+          name: wbhk-crd-srv
+          protocol: TCP
+        - containerPort: 9444
+          name: wbhk-pusher-srv
+          protocol: TCP
+      serviceAccountName: {{ .Release.Name }}-providers-controller-manager
+      terminationGracePeriodSeconds: 10
+      {{- if .Values.providers.gitlab.tolerations }}
+      tolerations: {{ toYaml .Values.providers.gitlab.controller.tolerations | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/0.2.1/templates/providers/provider-leader_election_role.yaml
+++ b/charts/0.2.1/templates/providers/provider-leader_election_role.yaml
@@ -1,0 +1,33 @@
+{{- if or (eq .Values.providers.github.enabled true) (eq .Values.providers.gitlab.enabled true) }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/name: role
+    app.kubernetes.io/instance: providers-leader-election-role
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  name: {{ .Release.Name }}-providers-leader-election-role
+rules:
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+{{- end }}

--- a/charts/0.2.1/templates/providers/providers-leader_election_role_binding.yaml
+++ b/charts/0.2.1/templates/providers/providers-leader_election_role_binding.yaml
@@ -1,0 +1,21 @@
+{{- if or (eq .Values.providers.github.enabled true) (eq .Values.providers.gitlab.enabled true) }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: rolebinding
+    app.kubernetes.io/instance: leader-election-rolebinding
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  name: {{ .Release.Name }}-providers-leader-election-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Release.Name }}-providers-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: {{ .Release.Name }}-providers-controller-manager
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/0.2.1/templates/providers/providers-role.yaml
+++ b/charts/0.2.1/templates/providers/providers-role.yaml
@@ -1,0 +1,91 @@
+{{- if or (eq .Values.providers.github.enabled true) (eq .Values.providers.gitlab.enabled true) }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-providers-manager-role
+rules:
+# Create and patch events related to kgio objects in any namespace
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - syngit.io
+  resources:
+  - remoteusers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - syngit.io
+  resources:
+  - remoteusers/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - syngit.io
+  resources:
+  - remoteuserbindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - syngit.io
+  resources:
+  - remoteuserbindings/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - syngit.io
+  resources:
+  - remoteuserbindings/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - syngit.io
+  resources:
+  - remotesyncers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - syngit.io
+  resources:
+  - remotesyncers/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - syngit.io
+  resources:
+  - remotesyncers/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+{{- end }}

--- a/charts/0.2.1/templates/providers/providers-role_binding.yaml
+++ b/charts/0.2.1/templates/providers/providers-role_binding.yaml
@@ -1,0 +1,21 @@
+{{- if or (eq .Values.providers.github.enabled true) (eq .Values.providers.gitlab.enabled true) }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: clusterrolebinding
+    app.kubernetes.io/instance: manager-rolebinding
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  name: {{ .Release.Name }}-providers-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Name }}-providers-manager-role
+subjects:
+- kind: ServiceAccount
+  name: {{ .Release.Name }}-providers-controller-manager
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/0.2.1/templates/providers/providers-service_account.yaml
+++ b/charts/0.2.1/templates/providers/providers-service_account.yaml
@@ -1,0 +1,13 @@
+{{- if or (eq .Values.providers.github.enabled true) (eq .Values.providers.gitlab.enabled true) }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/name: serviceaccount
+    app.kubernetes.io/instance: controller-manager-sa
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  name: {{ .Release.Name }}-providers-controller-manager
+{{- end }}

--- a/charts/0.2.1/templates/rbac/controller/auth_proxy_client_clusterrole.yaml
+++ b/charts/0.2.1/templates/rbac/controller/auth_proxy_client_clusterrole.yaml
@@ -1,0 +1,18 @@
+# {{- if eq .Values.controller.rbacProxy.enabled true }}
+# ---
+# apiVersion: rbac.authorization.k8s.io/v1
+# kind: ClusterRole
+# metadata:
+#   labels:
+#     app.kubernetes.io/name: clusterrole
+#     app.kubernetes.io/instance: metrics-reader
+#     app.kubernetes.io/component: kube-rbac-proxy
+#     app.kubernetes.io/created-by: {{ .Release.Name }}
+#     app.kubernetes.io/part-of: {{ .Release.Name }}
+#   name: {{ .Release.Name }}-metrics-reader
+# rules:
+# - nonResourceURLs:
+#   - "/metrics"
+#   verbs:
+#   - get
+# {{- end }}

--- a/charts/0.2.1/templates/rbac/controller/auth_proxy_role.yaml
+++ b/charts/0.2.1/templates/rbac/controller/auth_proxy_role.yaml
@@ -1,0 +1,26 @@
+{{- if eq .Values.controller.rbacProxy.enabled true }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/instance: proxy-role
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  name: {{ .Release.Name }}-proxy-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+{{- end }}

--- a/charts/0.2.1/templates/rbac/controller/auth_proxy_role_binding.yaml
+++ b/charts/0.2.1/templates/rbac/controller/auth_proxy_role_binding.yaml
@@ -1,0 +1,21 @@
+{{- if eq .Values.controller.rbacProxy.enabled true }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: clusterrolebinding
+    app.kubernetes.io/instance: proxy-rolebinding
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  name: {{ .Release.Name }}-proxy-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Name }}-proxy-role
+subjects:
+- kind: ServiceAccount
+  name: {{ .Release.Name }}-controller-manager
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/0.2.1/templates/rbac/controller/leader_election_role.yaml
+++ b/charts/0.2.1/templates/rbac/controller/leader_election_role.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/name: role
+    app.kubernetes.io/instance: leader-election-role
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  name: {{ .Release.Name }}-leader-election-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch

--- a/charts/0.2.1/templates/rbac/controller/leader_election_role_binding.yaml
+++ b/charts/0.2.1/templates/rbac/controller/leader_election_role_binding.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: rolebinding
+    app.kubernetes.io/instance: leader-election-rolebinding
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  name: {{ .Release.Name }}-leader-election-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Release.Name }}-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: {{ .Release.Name }}-controller-manager
+  namespace: {{ .Release.Namespace }}

--- a/charts/0.2.1/templates/rbac/controller/role.yaml
+++ b/charts/0.2.1/templates/rbac/controller/role.yaml
@@ -1,0 +1,111 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-manager-role
+rules:
+# Any resources can be pushed to the git repo.
+# The scope depends but the controller
+#  needs to be able to get,list,watch any of them
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+# Create and patch events related to kgio objects in any namespace
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - validatingwebhookconfigurations
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - syngit.io
+  resources:
+  - remoteusers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - syngit.io
+  resources:
+  - remoteusers/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - syngit.io
+  resources:
+  - remoteuserbindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - syngit.io
+  resources:
+  - remoteuserbindings/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - syngit.io
+  resources:
+  - remoteuserbindings/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - syngit.io
+  resources:
+  - remotesyncers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - syngit.io
+  resources:
+  - remotesyncers/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - syngit.io
+  resources:
+  - remotesyncers/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create

--- a/charts/0.2.1/templates/rbac/controller/role_binding.yaml
+++ b/charts/0.2.1/templates/rbac/controller/role_binding.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: clusterrolebinding
+    app.kubernetes.io/instance: manager-rolebinding
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  name: {{ .Release.Name }}-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Name }}-manager-role
+subjects:
+- kind: ServiceAccount
+  name: {{ .Release.Name }}-controller-manager
+  namespace: {{ .Release.Namespace }}

--- a/charts/0.2.1/templates/rbac/controller/service_account.yaml
+++ b/charts/0.2.1/templates/rbac/controller/service_account.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/name: serviceaccount
+    app.kubernetes.io/instance: controller-manager-sa
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  name: {{ .Release.Name }}-controller-manager

--- a/charts/0.2.1/templates/rbac/end-user/remotesyncer_editor_role.yaml
+++ b/charts/0.2.1/templates/rbac/end-user/remotesyncer_editor_role.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/instance: remotesyncers-editor-role
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  name: {{ .Release.Name }}-remotesyncers-editor-role
+rules:
+- apiGroups:
+  - syngit.io
+  resources:
+  - remotesyncers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - syngit.io
+  resources:
+  - remotesyncers/status
+  verbs:
+  - get

--- a/charts/0.2.1/templates/rbac/end-user/remotesyncer_viewer_role.yaml
+++ b/charts/0.2.1/templates/rbac/end-user/remotesyncer_viewer_role.yaml
@@ -1,0 +1,26 @@
+# permissions for end users to view remotesyncers.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/instance: remotesyncers-viewer-role
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  name: {{ .Release.Name }}-remotesyncers-viewer-role
+rules:
+- apiGroups:
+  - syngit.io
+  resources:
+  - remotesyncers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - syngit.io
+  resources:
+  - remotesyncers/status
+  verbs:
+  - get

--- a/charts/0.2.1/templates/rbac/end-user/remoteuser_editor_role.yaml
+++ b/charts/0.2.1/templates/rbac/end-user/remoteuser_editor_role.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/instance: remoteuser-editor-role
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  name: {{ .Release.Name }}-remoteuser-editor-role
+rules:
+- apiGroups:
+  - syngit.io
+  resources:
+  - remoteusers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - syngit.io
+  resources:
+  - remoteusers/status
+  verbs:
+  - get

--- a/charts/0.2.1/templates/rbac/end-user/remoteuser_viewer_role.yaml
+++ b/charts/0.2.1/templates/rbac/end-user/remoteuser_viewer_role.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/instance: gitremote-viewer-role
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  name: {{ .Release.Name }}-gitremote-viewer-role
+rules:
+- apiGroups:
+  - syngit.io
+  resources:
+  - remoteusers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - syngit.io
+  resources:
+  - remoteusers/status
+  verbs:
+  - get

--- a/charts/0.2.1/templates/rbac/end-user/remoteuserbinding_editor_role.yaml
+++ b/charts/0.2.1/templates/rbac/end-user/remoteuserbinding_editor_role.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/instance: remoteuserbinding-editor-role
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  name: {{ .Release.Name }}-remoteuserbinding-editor-role
+rules:
+- apiGroups:
+  - syngit.io
+  resources:
+  - remoteuserbindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - syngit.io
+  resources:
+  - remoteuserbindings/status
+  verbs:
+  - get

--- a/charts/0.2.1/templates/rbac/end-user/remoteuserbinding_viewer_role.yaml
+++ b/charts/0.2.1/templates/rbac/end-user/remoteuserbinding_viewer_role.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/instance: remoteuserbinding-viewer-role
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  name: {{ .Release.Name }}-remoteuserbinding-viewer-role
+rules:
+- apiGroups:
+  - syngit.io
+  resources:
+  - remoteuserbindings
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - syngit.io
+  resources:
+  - remoteuserbindings/status
+  verbs:
+  - get

--- a/charts/0.2.1/templates/webhook/webhook-service.yaml
+++ b/charts/0.2.1/templates/webhook/webhook-service.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: service
+    app.kubernetes.io/instance: webhook-crd-service
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  name: webhook-crd-service
+spec:
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 9443
+  selector:
+    control-plane: controller-manager
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: service
+    app.kubernetes.io/instance: syngit-remote-syncer-webhook-service
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  name: syngit-remote-syncer-webhook-service
+spec:
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 9444
+  selector:
+    control-plane: controller-manager

--- a/charts/0.2.1/templates/webhook/webhook.yaml
+++ b/charts/0.2.1/templates/webhook/webhook.yaml
@@ -1,0 +1,92 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: {{ .Release.Namespace }}-validating-webhook-configuration
+  {{- if eq .Values.webhook.certmanager.enabled true }}
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/operator-webhook-cert
+  {{- end }}
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-crd-service
+      namespace: {{ .Release.Namespace }}
+      path: /validate-syngit-io-v1beta2-remoteuser
+  failurePolicy: Fail
+  name: vremoteuser.kb.io
+  rules:
+  - apiGroups:
+    - syngit.io
+    apiVersions:
+    - v1beta2
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - remoteusers
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-crd-service
+      namespace: {{ .Release.Namespace }}
+      path: /syngit-v1beta2-remotesyncer-rules-permissions
+  failurePolicy: Fail
+  name: vremotesyncers-rules-permissions.v1beta2.syngit.io
+  rules:
+  - apiGroups:
+    - syngit.io
+    apiVersions:
+    - v1beta2
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - remotesyncers
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-crd-service
+      namespace: {{ .Release.Namespace }}
+      path: /validate-syngit-io-v1beta2-remotesyncer
+  failurePolicy: Fail
+  name: vremotesyncer.kb.io
+  rules:
+  - apiGroups:
+    - syngit.io
+    apiVersions:
+    - v1beta2
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - remotesyncers
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-crd-service
+      namespace: {{ .Release.Namespace }}
+      path: /syngit-v1beta2-remoteuser-association
+  failurePolicy: Fail
+  name: vremoteusers-association.v1beta2.syngit.io
+  rules:
+  - apiGroups:
+    - syngit.io
+    apiVersions:
+    - v1beta2
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - remoteusers
+  sideEffects: None

--- a/charts/0.2.1/values.yaml
+++ b/charts/0.2.1/values.yaml
@@ -1,0 +1,165 @@
+webhook:
+  certmanager:
+    enabled: true
+    certificate:
+      name: webhook-cert
+      secret: webhook-server-cert
+
+controller:
+  image:
+    prefix: ghcr.io/syngit-org
+    name: syngit
+    tag: v0.2.0
+    # imagePullSecrets:
+    # imagePullPolicy:
+
+  securityContext:
+    runAsUser: 1000
+    allowPrivilegeEscalation: false
+    privileged: false
+    runAsNonRoot: true
+    seccompProfile:
+      type: "RuntimeDefault"
+    capabilities:
+      drop:
+      - "ALL"
+  resources:
+    limits:
+      cpu: 500m
+      memory: 128Mi
+    requests:
+      cpu: 10m
+      memory: 64Mi
+  tolerations: []
+
+  metrics:
+    enabled: false
+    bindAddress: 127.0.0.1:8080
+
+  rbacProxy:
+    enabled: false
+    upstreamAddress: http://127.0.0.1:8080/
+    resources:
+      limits:
+        cpu: 500m
+        memory: 128Mi
+      requests:
+        cpu: 5m
+        memory: 64Mi
+    securityContext:
+      runAsUser: 1000
+      allowPrivilegeEscalation: false
+      privileged: false
+      runAsNonRoot: true
+      seccompProfile:
+        type: "RuntimeDefault"
+      capabilities:
+        drop:
+        - "ALL"
+
+  dynamicWebhookName: "remotesyncer.syngit.io"
+
+monitoring:
+  enabled: false
+
+installCRD: true
+
+providers:
+  gitlab:
+    controller:
+      # imagePullSecrets:
+      # imagePullPolicy:
+
+      securityContext:
+        runAsUser: 1000
+        allowPrivilegeEscalation: false
+        privileged: false
+        runAsNonRoot: true
+        seccompProfile:
+          type: "RuntimeDefault"
+        capabilities:
+          drop:
+          - "ALL"
+      resources:
+        limits:
+          cpu: 500m
+          memory: 128Mi
+        requests:
+          cpu: 10m
+          memory: 64Mi
+      tolerations: []
+
+      metrics:
+        enabled: false
+        bindAddress: 127.0.0.1:8080
+
+      rbacProxy:
+        enabled: false
+        upstreamAddress: http://127.0.0.1:8080/
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 64Mi
+        securityContext:
+          runAsUser: 1000
+          allowPrivilegeEscalation: false
+          privileged: false
+          runAsNonRoot: true
+          seccompProfile:
+            type: "RuntimeDefault"
+          capabilities:
+            drop:
+            - "ALL"
+    enabled: false
+  github:
+    controller:
+      # imagePullSecrets:
+      # imagePullPolicy:
+
+      securityContext:
+        runAsUser: 1000
+        allowPrivilegeEscalation: false
+        privileged: false
+        runAsNonRoot: true
+        seccompProfile:
+          type: "RuntimeDefault"
+        capabilities:
+          drop:
+          - "ALL"
+      resources:
+        limits:
+          cpu: 500m
+          memory: 128Mi
+        requests:
+          cpu: 10m
+          memory: 64Mi
+      tolerations: []
+
+      metrics:
+        enabled: false
+        bindAddress: 127.0.0.1:8080
+
+      rbacProxy:
+        enabled: false
+        upstreamAddress: http://127.0.0.1:8080/
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 64Mi
+        securityContext:
+          runAsUser: 1000
+          allowPrivilegeEscalation: false
+          privileged: false
+          runAsNonRoot: true
+          seccompProfile:
+            type: "RuntimeDefault"
+          capabilities:
+            drop:
+            - "ALL"
+    enabled: false


### PR DESCRIPTION
New version to implement Github & Gitlab external providers features. Each of them is implemented in a different pod.
The project & images for these providers can be found here:
- https://github.com/syngit-org/syngit-provider-github
- https://github.com/syngit-org/syngit-provider-gitlab

For now, they are both in version `v0.0.1` which implement an unique feature: test the authentication for an user when creating a `RemoteUser` using a specific annotation (`github.syngit.io/auth.test: "true"` or `gitlab.syngit.io/auth.test: "true"`)