### PR TITLE
:bug: Fix wrong ca bundle getter

### DIFF
--- a/internal/interceptor/git_pusher.go
+++ b/internal/interceptor/git_pusher.go
@@ -33,7 +33,7 @@ type GitPusher struct {
 	gitToken              string
 	operation             admissionv1.Operation
 	insecureSkipTlsVerify bool
-	caBundle              string
+	caBundle              []byte
 }
 
 type GitPushResponse struct {
@@ -58,8 +58,8 @@ func (gp *GitPusher) Push() (GitPushResponse, error) {
 		InsecureSkipTLS: gp.insecureSkipTlsVerify,
 		Progress:        io.MultiWriter(&verboseOutput),
 	}
-	if gp.caBundle != "" {
-		cloneOption.CABundle = []byte(gp.caBundle)
+	if gp.caBundle != nil {
+		cloneOption.CABundle = gp.caBundle
 	}
 	repo, err := git.Clone(memory.NewStorage(), memfs.New(), cloneOption)
 	if err != nil {
@@ -268,8 +268,8 @@ func (gp *GitPusher) pushChanges(repo *git.Repository) error {
 		InsecureSkipTLS: gp.insecureSkipTlsVerify,
 		Progress:        io.MultiWriter(&verboseOutput), // Capture verbose output
 	}
-	if gp.caBundle != "" {
-		pushOptions.CABundle = []byte(gp.caBundle)
+	if gp.caBundle != nil {
+		pushOptions.CABundle = gp.caBundle
 	}
 	err := repo.Push(pushOptions)
 	if err != nil {

--- a/internal/interceptor/webhook_request_checker.go
+++ b/internal/interceptor/webhook_request_checker.go
@@ -47,7 +47,7 @@ type wrcDetails struct {
 	commitHash            string
 	gitUser               gitUser
 	insecureSkipTlsVerify bool
-	caBundle              string
+	caBundle              []byte
 	pushDetails           string
 
 	// Error
@@ -430,7 +430,7 @@ func (wrc *WebhookRequestChecker) tlsContructor(details *wrcDetails) error {
 	if caErr != nil {
 		return caErr
 	}
-	if caBundleRsy != "" {
+	if caBundleRsy != nil {
 		caBundle = caBundleRsy
 	}
 

--- a/pkg/utils/ca-finder.go
+++ b/pkg/utils/ca-finder.go
@@ -12,13 +12,13 @@ import (
 
 const CaSecretWrongTypeErrorMessage = "the CA bundle secret must be of type \"kubernetes.io/ts\""
 
-func FindGlobalCABundle(client client.Client, host string) (string, error) {
+func FindGlobalCABundle(client client.Client, host string) ([]byte, error) {
 	return FindCABundle(client, os.Getenv("MANAGER_NAMESPACE"), host+"-ca-bundle")
 }
 
-func FindCABundle(client client.Client, namespace string, name string) (string, error) {
+func FindCABundle(client client.Client, namespace string, name string) ([]byte, error) {
 	if name == "" {
-		return "", nil
+		return nil, nil
 	}
 
 	ctx := context.Background()
@@ -27,10 +27,10 @@ func FindCABundle(client client.Client, namespace string, name string) (string, 
 
 	err := client.Get(ctx, globalNamespacedName, caBundleSecret)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	if caBundleSecret.Type != "kubernetes.io/tls" {
-		return "", errors.New(CaSecretWrongTypeErrorMessage)
+		return nil, errors.New(CaSecretWrongTypeErrorMessage)
 	}
-	return caBundleSecret.StringData["tls.crt"], nil
+	return caBundleSecret.Data["tls.crt"], nil
 }


### PR DESCRIPTION
The way the ca bundle was retrieved from the secret was by looking at the `stringData`. But this is actually empty and we have to look into `data` instead.