### PR TITLE
:seedling: Refactor RBAC for tests + convert errors to type

### DIFF
--- a/internal/patterns/v1beta3/remoteuser_association.go
+++ b/internal/patterns/v1beta3/remoteuser_association.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	syngit "github.com/syngit-org/syngit/pkg/api/v1beta3"
+	"github.com/syngit-org/syngit/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -93,7 +94,8 @@ func (ruap *RemoteUserAssociationPattern) Diff(ctx context.Context) *ErrorPatter
 		}
 
 		if isAlreadyDefined && name != existingRemoteUserBindingName {
-			return &ErrorPattern{Message: fmt.Sprintf("the RemoteUser is already bound in the RemoteUserBinding %s", existingRemoteUserBindingName), Reason: Denied}
+			denied := utils.RemoteUserAlreadyBoundError{ExistingRemoteUserBindingName: existingRemoteUserBindingName}
+			return &ErrorPattern{Message: denied.Error(), Reason: Denied}
 		}
 
 		// CREATE the RemoteUserBinding
@@ -138,7 +140,8 @@ func (ruap *RemoteUserAssociationPattern) Diff(ctx context.Context) *ErrorPatter
 		name = rub.Name
 
 		if isAlreadyDefined && name != existingRemoteUserBindingName {
-			return &ErrorPattern{Message: fmt.Sprintf("the RemoteUser is already bound in the RemoteUserBinding %s", existingRemoteUserBindingName), Reason: Denied}
+			denied := utils.RemoteUserAlreadyBoundError{ExistingRemoteUserBindingName: existingRemoteUserBindingName}
+			return &ErrorPattern{Message: denied.Error(), Reason: Denied}
 		}
 
 		remoteUserBinding := &syngit.RemoteUserBinding{}

--- a/internal/patterns/v1beta3/remoteuser_searchremotetarget.go
+++ b/internal/patterns/v1beta3/remoteuser_searchremotetarget.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	syngit "github.com/syngit-org/syngit/pkg/api/v1beta3"
+	"github.com/syngit-org/syngit/pkg/utils"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -60,7 +61,8 @@ func (rusp *RemoteUserSearchRemoteTargetPattern) Diff(ctx context.Context) *Erro
 		return &ErrorPattern{Message: fmt.Sprintf("only one RemoteUserBinding for the user %s should be managed by Syngit", rusp.Username), Reason: Denied}
 	}
 	if len(remoteUserBindingList.Items) == 0 {
-		return &ErrorPattern{Message: fmt.Sprintf("webhook server error: no RemoteUserBinding found for %s", rusp.Username), Reason: Errored}
+		notFoundError := utils.RemoteUserBindingNotFoundError{Username: rusp.Username}
+		return &ErrorPattern{Message: notFoundError.Error(), Reason: Errored}
 	}
 	rusp.RemoteUserBinding = &remoteUserBindingList.Items[0]
 

--- a/internal/webhook/v1beta3/remotesyncer_rules_permissions.go
+++ b/internal/webhook/v1beta3/remotesyncer_rules_permissions.go
@@ -37,7 +37,8 @@ func (rswh *RemoteSyncerWebhookHandler) Handle(ctx context.Context, req admissio
 		if authorized {
 			return admission.Allowed(fmt.Sprintf("The user %s is allowed to scope all of the listed resources", user))
 		} else {
-			return admission.Denied(fmt.Sprintf("The user %s is not allowed to scope: \n- %s", user, strings.Join(forbiddenResources, "\n- ")))
+			denied := utils.ResourceScopeForbiddenError{User: user, ForbiddenResources: forbiddenResources}
+			return admission.Denied(denied.Error())
 		}
 	}
 }

--- a/internal/webhook/v1beta3/remoteuser_secrets_permissions.go
+++ b/internal/webhook/v1beta3/remoteuser_secrets_permissions.go
@@ -58,7 +58,8 @@ func (ruwh *RemoteUserPermissionsWebhookHandler) Handle(ctx context.Context, req
 	}
 
 	if !sar.Status.Allowed {
-		return admission.Denied(fmt.Sprintf("The user %s is not allowed to get the secret: %s", user, ru.Spec.SecretRef.Name))
+		denied := utils.DenyGetSecretError{User: user, SecretRef: ru.Spec.SecretRef}
+		return admission.Denied(denied.Error())
 	}
 
 	return admission.Allowed(fmt.Sprintf("The user %s is allowed to get the secret: %s", user, ru.Spec.SecretRef.Name))

--- a/internal/webhook/v1beta3/remoteuserbinding_permissions.go
+++ b/internal/webhook/v1beta3/remoteuserbinding_permissions.go
@@ -59,7 +59,8 @@ func (rubwh *RemoteUserBindingPermissionsWebhookHandler) Handle(ctx context.Cont
 		}
 
 		if !sar.Status.Allowed {
-			return admission.Denied(fmt.Sprintf("The user %s is not allowed to get the referenced remoteuser: %s", user, ru.Name))
+			denied := utils.DenyGetRemoteUserError{User: user, RemoteUserRef: ru}
+			return admission.Denied(denied.Error())
 		}
 
 	}

--- a/pkg/utils/errors.go
+++ b/pkg/utils/errors.go
@@ -1,0 +1,537 @@
+package utils
+
+import (
+	"fmt"
+	"strings"
+
+	syngit "github.com/syngit-org/syngit/pkg/api/v1beta3"
+	authv1 "k8s.io/api/authentication/v1"
+	v1 "k8s.io/api/core/v1"
+)
+
+// REMOTE SYNCER WEBHOOK
+
+/*
+	This error must be used when the user is not allowed to
+	select a set of resources for interception.
+*/
+
+type ResourceScopeForbiddenError struct {
+	User               authv1.UserInfo
+	ForbiddenResources []string
+}
+
+func (rsfe ResourceScopeForbiddenError) Error() string {
+	return fmt.Sprintf("The user %s is not allowed to scope: \n- %s",
+		rsfe.User,
+		strings.Join(rsfe.ForbiddenResources, "\n- "),
+	)
+}
+
+func (rsfe ResourceScopeForbiddenError) ShouldContains(errorString string) bool {
+	for _, str := range []string{
+		"The user ",
+		" is not allowed to scope: ",
+	} {
+		if !strings.Contains(errorString, str) {
+			return false
+		}
+	}
+	return true
+}
+
+// REMOTE USER PATTERN ASSOCIATION WEBHOOK
+
+/*
+	This error must be used when the RemoteUser that
+	suppose to be associated with a RemoteUserBinding
+	using the pattern is already associated with another one.
+*/
+
+type RemoteUserAlreadyBoundError struct {
+	ExistingRemoteUserBindingName string
+}
+
+func (ruabe RemoteUserAlreadyBoundError) Error() string {
+	return fmt.Sprintf("the RemoteUser is already bound in the RemoteUserBinding %s",
+		ruabe.ExistingRemoteUserBindingName,
+	)
+}
+
+func (ruabe RemoteUserAlreadyBoundError) ShouldContains(errorString string) bool {
+	for _, str := range []string{
+		"the RemoteUser is already bound in the RemoteUserBinding ",
+	} {
+		if !strings.Contains(errorString, str) {
+			return false
+		}
+	}
+	return true
+}
+
+/*
+	This interface must be used by the errors that
+	are raised during the interception process.
+
+	Terminology used in this file:
+	"user": the user that trigger an interception
+					by creating, updating or deleting a resource
+*/
+
+type ResourceInterceptorError interface {
+	Error() string
+	ShouldContains(errorString string) bool
+}
+
+func ErrorTypeChecker(errorType ResourceInterceptorError, errorString string) bool {
+	return errorType.ShouldContains(errorString)
+}
+
+// ---
+
+/*
+	This error must be used when the user is not allowed
+	to get the secret referenced by its own RemoteUser.
+*/
+
+type DenyGetSecretError struct {
+	User      authv1.UserInfo
+	SecretRef v1.SecretReference
+}
+
+func (gse DenyGetSecretError) Error() string {
+	return fmt.Sprintf("The user %s is not allowed to get the secret: %s",
+		gse.User,
+		gse.SecretRef.Name,
+	)
+}
+
+func (gse DenyGetSecretError) ShouldContains(errorString string) bool {
+	for _, str := range []string{
+		"The user ",
+		" is not allowed to get the secret: ",
+	} {
+		if !strings.Contains(errorString, str) {
+			return false
+		}
+	}
+	return true
+}
+
+// ---
+
+/*
+	This error must be used when the user is not allowed
+	to get its own RemoteUser.
+*/
+
+type DenyGetRemoteUserError struct {
+	User          authv1.UserInfo
+	RemoteUserRef v1.ObjectReference
+}
+
+func (grue DenyGetRemoteUserError) Error() string {
+	return fmt.Sprintf("The user %s is not allowed to get the referenced remoteuser: %s",
+		grue.User,
+		grue.RemoteUserRef.Name,
+	)
+}
+
+func (grue DenyGetRemoteUserError) ShouldContains(errorString string) bool {
+	for _, str := range []string{
+		"The user ",
+		" is not allowed to get the referenced remoteuser: ",
+	} {
+		if !strings.Contains(errorString, str) {
+			return false
+		}
+	}
+	return true
+}
+
+/*
+	This error must be used when there is no RemoteUserBinding
+	referencing the user as the subject.
+*/
+
+type RemoteUserBindingNotFoundError struct {
+	Username string
+}
+
+func (rubnfe RemoteUserBindingNotFoundError) Error() string {
+	return fmt.Sprintf("no RemoteUserBinding found for the user %s",
+		rubnfe.Username,
+	)
+}
+
+func (rubnfe RemoteUserBindingNotFoundError) ShouldContains(errorString string) bool {
+	for _, str := range []string{
+		"no RemoteUserBinding found for the user ",
+	} {
+		if !strings.Contains(errorString, str) {
+			return false
+		}
+	}
+	return true
+}
+
+/*
+	This error must be used when the defaultRemoteUser
+	referenced in the RemoteSyncer does not exists.
+*/
+
+type DefaultRemoteUserNotFoundError struct {
+	DefaultUserName string
+}
+
+func (drunfe DefaultRemoteUserNotFoundError) Error() string {
+	return fmt.Sprintf("the default RemoteUser is not found: %s",
+		drunfe.DefaultUserName,
+	)
+}
+
+func (drunfe DefaultRemoteUserNotFoundError) ShouldContains(errorString string) bool {
+	for _, str := range []string{
+		"the default RemoteUser is not found: ",
+	} {
+		if !strings.Contains(errorString, str) {
+			return false
+		}
+	}
+	return true
+}
+
+/*
+	This error must be used when the defaultRemoteTarget
+	referenced in the RemoteSyncer does not exists.
+*/
+
+type DefaultRemoteTargetNotFoundError struct {
+	DefaultTargetName string
+}
+
+func (drtnfe DefaultRemoteTargetNotFoundError) Error() string {
+	return fmt.Sprintf("the default RemoteTarget is not found: %s",
+		drtnfe.DefaultTargetName,
+	)
+}
+
+func (drtnfe DefaultRemoteTargetNotFoundError) ShouldContains(errorString string) bool {
+	for _, str := range []string{
+		"the default RemoteTarget is not found: ",
+	} {
+		if !strings.Contains(errorString, str) {
+			return false
+		}
+	}
+	return true
+}
+
+/*
+	This error must be used when the defaultRemoteUser's fqdn
+	does not match the RemoteSyncer's fqdn.
+*/
+
+type DefaultRemoteTargetMismatchError struct {
+	RemoteSyncer syngit.RemoteSyncer
+	RemoteUser   syngit.RemoteUser
+}
+
+func (drtme DefaultRemoteTargetMismatchError) Error() string {
+	return fmt.Sprintf("the fqdn of the default RemoteUser does not match the associated RemoteSyncer (%s) fqdn (%s)",
+		drtme.RemoteSyncer.Name,
+		drtme.RemoteUser.Name,
+	)
+}
+
+// ---
+
+type SameUpstreamDifferentMergeStrategyError struct {
+	UpstreamRepository string
+	UpstreamBranch     string
+	TargetRepository   string
+	TargetBranch       string
+	MergeStrategy      string
+}
+
+func (sudmse SameUpstreamDifferentMergeStrategyError) Error() string {
+	return "should not be set when the target repo & target branch are the same as the upstream repo & branch"
+}
+
+func (sudmse SameUpstreamDifferentMergeStrategyError) ShouldContains(errorString string) bool {
+	for _, str := range []string{
+		sudmse.Error(),
+	} {
+		if !strings.Contains(errorString, str) {
+			return false
+		}
+	}
+	return true
+}
+
+// ---
+
+type DifferentUpstreamEmptyMergeStrategyError struct {
+	UpstreamRepository string
+	UpstreamBranch     string
+	TargetRepository   string
+	TargetBranch       string
+	MergeStrategy      string
+}
+
+func (duemse DifferentUpstreamEmptyMergeStrategyError) Error() string {
+	return "should be set when the target repo & target branch are different from the upstream repo & branch"
+}
+
+func (duemse DifferentUpstreamEmptyMergeStrategyError) ShouldContains(errorString string) bool {
+	for _, str := range []string{
+		duemse.Error(),
+	} {
+		if !strings.Contains(errorString, str) {
+			return false
+		}
+	}
+	return true
+}
+
+/*
+	This error must be used when there is not RemoteTarget
+	corresponding to these requirements:
+	- remoteTargetLabelSelector
+	- upstream repo = remotesyncer repository
+	- upstream branch = remotesyncer default branch
+*/
+
+type RemoteTargetNotFoundError struct{}
+
+func (rtnfe RemoteTargetNotFoundError) Error() string {
+	return "no RemoteTarget found"
+}
+
+func (rtnfe RemoteTargetNotFoundError) ShouldContains(errorString string) bool {
+	for _, str := range []string{
+		rtnfe.Error(),
+	} {
+		if !strings.Contains(errorString, str) {
+			return false
+		}
+	}
+	return true
+}
+
+/*
+	This error must be used when there is no RemoteUser
+	corresponding to these requirements:
+	- remoteuser fqdn = remotesyncer fqdn
+	- only one remoteuser found for this user for this platform
+*/
+
+type RemoteUserSearchErrorReason string
+
+const (
+	RemoteUserNotFound         RemoteUserSearchErrorReason = "no RemoteUser found for the current user with this fqdn: "
+	MoreThanOneRemoteUserFound RemoteUserSearchErrorReason = "more than one RemoteUser found for the current user with this fqdn: "
+)
+
+type RemoteUserSearchError struct {
+	Reason RemoteUserSearchErrorReason
+	Fqdn   string
+}
+
+func (ruse RemoteUserSearchError) Error() string {
+	return fmt.Sprintf("%s%s", ruse.Reason, ruse.Fqdn)
+}
+
+func (ruse RemoteUserSearchError) ShouldContains(errorString string) bool {
+	if strings.Contains(errorString, string(RemoteUserNotFound)) {
+		return true
+	}
+	if strings.Contains(errorString, string(MoreThanOneRemoteUserFound)) {
+		return true
+	}
+	return false
+}
+
+/*
+	This error must be used when there is no Secret
+	corresponding to these requirements:
+	- the secret referenced by the remoteuser must exists
+	- the secret's type = kubernetes.io/basic-auth
+*/
+
+type CrendentialSearchErrorReason string
+
+const (
+	SecretNotFound         CrendentialSearchErrorReason = "no Secret found for the current user to log on the git repository with the RemoteUser: %s"
+	MoreThanOneSecretFound CrendentialSearchErrorReason = "more than one Secret found for the current user with the RemoteUser: %s"
+	TokenNotFound          CrendentialSearchErrorReason = "no token found in the secret for the RemoteUser: %s; the token must be specified in the password field and the secret type must be kubernetes.io/basic-auth"
+)
+
+type CrendentialSearchError struct {
+	Reason     CrendentialSearchErrorReason
+	RemoteUser syngit.RemoteUser
+}
+
+func (cse CrendentialSearchError) Error() string {
+	return fmt.Sprintf(string(cse.Reason), cse.RemoteUser.Name)
+}
+
+func (cse CrendentialSearchError) ShouldContains(errorString string) bool {
+	if strings.Contains(errorString, string(SecretNotFound)) {
+		return true
+	}
+	if strings.Contains(errorString, string(MoreThanOneSecretFound)) {
+		return true
+	}
+	if strings.Contains(errorString, string(TokenNotFound)) {
+		return true
+	}
+	return false
+}
+
+/*
+	This error must be used when the RemoteTarget
+	does not match the RemoteSyncer's spec.
+	Currently used on the defaultRemoteTarget.
+*/
+
+type RemoteTargetSearchError struct {
+	UpstreamRepository string
+	UpstreamBranch     string
+	TargetRepository   string
+	TargetBranch       string
+}
+
+func (rtse RemoteTargetSearchError) Error() string {
+	return fmt.Sprintf(
+		"the RemoteSyncer's repository or branch does not match the upstream repository or branch of the default RemoteTarget. RemoteSyncer repo: %s; RemoteSyncer branch: %s; RemoteTarget upstream repo: %s; RemoteTarget upstream branch: %s",
+		rtse.UpstreamRepository,
+		rtse.UpstreamBranch,
+		rtse.TargetRepository,
+		rtse.TargetBranch,
+	)
+}
+
+func (rtse RemoteTargetSearchError) ShouldContains(errorString string) bool {
+	return strings.Contains(errorString, "the RemoteSyncer's repository or branch does not match the upstream repository or branch of the default RemoteTarget. RemoteSyncer repo: ")
+}
+
+/*
+	This error must be used when there is more than one
+	RemoteTarget matching the upstream spec of the RemoteSyncer
+	while the defined targetStrategy is "OneTarget".
+*/
+
+type MultipleTargetError struct {
+	RemoteTargetsCount int
+}
+
+func (mte MultipleTargetError) Error() string {
+	return "multiple RemoteTargets found for OneTarget set as the TargetStrategy in the RemoteSyncer"
+}
+
+func (mte MultipleTargetError) ShouldContains(errorString string) bool {
+	return strings.Contains(errorString, mte.Error())
+}
+
+// ---
+
+type LabelSeletorParsingErrorKind string
+
+const (
+	RemoteUserBindingSelectorError LabelSeletorParsingErrorKind = "error parsing the LabelSelector for the remoteUserBindingSelector: "
+	RemoteTargetSelectorError      LabelSeletorParsingErrorKind = "error parsing the LabelSelector for the remoteTargetSelector: "
+)
+
+type LabelSeletorParsingError struct {
+	Kind       LabelSeletorParsingErrorKind
+	LabelError error
+}
+
+func (lspe LabelSeletorParsingError) Error() string {
+	return fmt.Sprintf("%s%s", lspe.Kind, lspe.LabelError)
+}
+
+func (lspe LabelSeletorParsingError) ShouldContains(errorString string) bool {
+	if strings.Contains(errorString, string(RemoteUserBindingSelectorError)) {
+		return true
+	}
+	if strings.Contains(errorString, string(RemoteTargetSelectorError)) {
+		return true
+	}
+	return false
+}
+
+/*
+	This error must be used when the dynamic interception
+	webhook receives an empty request.
+*/
+
+type EmptyRequestError struct{}
+
+func (ere EmptyRequestError) Error() string {
+	return "the request is empty and it should not be"
+}
+
+func (ere EmptyRequestError) ShouldContains(errorString string) bool {
+	return strings.Contains(errorString, ere.Error())
+}
+
+/*
+	This error must be used when multiple
+	RemoteUserBinding	with the same subject exist.
+*/
+
+type MultipleRemoteUserBindingError struct {
+	RemoteUserBindingsCount int
+}
+
+func (mrube MultipleRemoteUserBindingError) Error() string {
+	return "multiple RemoteUserBinding found OR the name of the user is not unique; this version of the operator work with the name as unique identifier for users"
+}
+
+func (mrube MultipleRemoteUserBindingError) ShouldContains(errorString string) bool {
+	return strings.Contains(errorString, mrube.Error())
+}
+
+// ---
+
+type GitUrlParseError struct {
+	ParseError error
+}
+
+func (gupe GitUrlParseError) Error() string {
+	return fmt.Sprintf("error parsing git repository URL: %s", gupe.ParseError)
+}
+
+func (gupe GitUrlParseError) ShouldContains(errorString string) bool {
+	return strings.Contains(errorString, "error parsing git repository URL")
+}
+
+// ---
+
+type NonUniqueUserError struct {
+	UserCount int
+}
+
+func (nuue NonUniqueUserError) Error() string {
+	return "the name of the user is not unique; this version of the operator work with the name as unique identifier for users"
+}
+
+func (nuue NonUniqueUserError) ShouldContains(errorString string) bool {
+	return strings.Contains(errorString, nuue.Error())
+}
+
+// ---
+
+type WrongYamlFormatError struct {
+	Yaml string
+}
+
+func (wyfe WrongYamlFormatError) Error() string {
+	return "failed to convert the excludedFields from the ConfigMap (wrong yaml format)"
+}
+
+func (wyfe WrongYamlFormatError) ShouldContains(errorString string) bool {
+	return strings.Contains(errorString, wyfe.Error())
+}

--- a/test/e2e/build/01_webhook_servers_test.go
+++ b/test/e2e/build/01_webhook_servers_test.go
@@ -22,6 +22,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	syngitUtils "github.com/syngit-org/syngit/pkg/utils"
 	"github.com/syngit-org/syngit/test/utils"
 )
 
@@ -46,7 +47,7 @@ var _ = Describe("01 Test webhook servers", Ordered, func() {
 			fmt.Sprintf("%s/sample_configmap.yaml", samplePath))
 		_, err = utils.Run(cmd)
 		ExpectWithOffset(2, err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("no RemoteUserBinding found for the user"))
+		Expect(syngitUtils.ErrorTypeChecker(&syngitUtils.RemoteUserBindingNotFoundError{}, err.Error())).To(BeTrue())
 
 	})
 

--- a/test/e2e/helm/install/01_webhook_servers_test.go
+++ b/test/e2e/helm/install/01_webhook_servers_test.go
@@ -22,6 +22,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	syngitutils "github.com/syngit-org/syngit/pkg/utils"
 	"github.com/syngit-org/syngit/test/utils"
 )
 
@@ -45,7 +46,7 @@ var _ = Describe("01 Test webhook servers", Ordered, func() {
 			fmt.Sprintf("%s/sample_configmap.yaml", samplePath))
 		_, err = utils.Run(cmd)
 		ExpectWithOffset(2, err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("no RemoteUserBinding found for the user"))
+		Expect(syngitutils.ErrorTypeChecker(&syngitutils.RemoteUserBindingNotFoundError{}, err.Error())).To(BeTrue())
 
 	})
 

--- a/test/e2e/helm/upgrade/01_webhook_servers_test.go
+++ b/test/e2e/helm/upgrade/01_webhook_servers_test.go
@@ -22,6 +22,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	syngitutils "github.com/syngit-org/syngit/pkg/utils"
 	"github.com/syngit-org/syngit/test/utils"
 )
 
@@ -45,7 +46,7 @@ var _ = Describe("01 Test webhook servers", Ordered, func() {
 			fmt.Sprintf("%s/sample_configmap.yaml", samplePath))
 		_, err = utils.Run(cmd)
 		ExpectWithOffset(2, err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("no RemoteUserBinding found for the user"))
+		Expect(syngitutils.ErrorTypeChecker(&syngitutils.RemoteUserBindingNotFoundError{}, err.Error())).To(BeTrue())
 
 	})
 

--- a/test/e2e/helm/upgrade/e2e_suite_test.go
+++ b/test/e2e/helm/upgrade/e2e_suite_test.go
@@ -25,6 +25,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/syngit-org/syngit/test/utils"
+
+	syngitutils "github.com/syngit-org/syngit/pkg/utils"
 )
 
 const (
@@ -88,7 +90,7 @@ var _ = BeforeSuite(func() {
 		fmt.Sprintf("%s/sample_configmap.yaml", samplePath))
 	_, err = utils.Run(cmd)
 	ExpectWithOffset(2, err).To(HaveOccurred())
-	Expect(err.Error()).To(ContainSubstring("no RemoteUserBinding found for the user"))
+	Expect(syngitutils.ErrorTypeChecker(&syngitutils.RemoteUserBindingNotFoundError{}, err.Error())).To(BeTrue())
 
 	By("deleting the RemoteSyncer")
 	Wait60()

--- a/test/e2e/syngit/02_commitonly_cm_test.go
+++ b/test/e2e/syngit/02_commitonly_cm_test.go
@@ -65,7 +65,7 @@ var _ = Describe("02 CommitOnly a ConfigMap", func() {
 			return err == nil
 		}, timeout, interval).Should(BeTrue())
 
-		repoUrl := "https://" + gitP1Fqdn + "/syngituser/blue.git"
+		repoUrl := fmt.Sprintf("https://%s/%s/%s.git", gitP1Fqdn, giteaBaseNs, repo1)
 		By("creating the RemoteSyncer")
 		remotesyncer := &syngit.RemoteSyncer{
 			ObjectMeta: metav1.ObjectMeta{
@@ -126,8 +126,8 @@ var _ = Describe("02 CommitOnly a ConfigMap", func() {
 		Wait3()
 		repo := &Repo{
 			Fqdn:  gitP1Fqdn,
-			Owner: "syngituser",
-			Name:  "blue",
+			Owner: giteaBaseNs,
+			Name:  repo1,
 		}
 		exists, err := IsObjectInRepo(*repo, cm)
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/syngit/03_commitapply_cm_test.go
+++ b/test/e2e/syngit/03_commitapply_cm_test.go
@@ -18,6 +18,7 @@ package e2e_syngit
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -64,7 +65,7 @@ var _ = Describe("03 CommitApply a ConfigMap", func() {
 			return err == nil
 		}, timeout, interval).Should(BeTrue())
 
-		repoUrl := "https://" + gitP1Fqdn + "/syngituser/blue.git"
+		repoUrl := fmt.Sprintf("https://%s/%s/%s.git", gitP1Fqdn, giteaBaseNs, repo1)
 		By("creating the RemoteSyncer")
 		remotesyncer := &syngit.RemoteSyncer{
 			ObjectMeta: metav1.ObjectMeta{
@@ -125,8 +126,8 @@ var _ = Describe("03 CommitApply a ConfigMap", func() {
 		Wait3()
 		repo := &Repo{
 			Fqdn:  gitP1Fqdn,
-			Owner: "syngituser",
-			Name:  "blue",
+			Owner: giteaBaseNs,
+			Name:  repo1,
 		}
 		exists, err := IsObjectInRepo(*repo, cm)
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/syngit/04_excludedfields_test.go
+++ b/test/e2e/syngit/04_excludedfields_test.go
@@ -18,6 +18,7 @@ package e2e_syngit
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -65,7 +66,7 @@ var _ = Describe("04 Create RemoteSyncer with excluded fields", func() {
 			return err == nil
 		}, timeout, interval).Should(BeTrue())
 
-		repoUrl := "https://" + gitP1Fqdn + "/syngituser/blue.git"
+		repoUrl := fmt.Sprintf("https://%s/%s/%s.git", gitP1Fqdn, giteaBaseNs, repo1)
 		By("creating the RemoteSyncer")
 		remotesyncer := &syngit.RemoteSyncer{
 			ObjectMeta: metav1.ObjectMeta{
@@ -140,8 +141,8 @@ var _ = Describe("04 Create RemoteSyncer with excluded fields", func() {
 		Wait3()
 		repo := &Repo{
 			Fqdn:  gitP1Fqdn,
-			Owner: "syngituser",
-			Name:  "blue",
+			Owner: giteaBaseNs,
+			Name:  repo1,
 		}
 		uidExists, err := IsFieldDefined(*repo, cm, "metadata.uid")
 		Expect(err).ToNot(HaveOccurred())
@@ -209,7 +210,7 @@ var _ = Describe("04 Create RemoteSyncer with excluded fields", func() {
 		)
 		Expect(err).ToNot(HaveOccurred())
 
-		repoUrl := "https://" + gitP1Fqdn + "/syngituser/blue.git"
+		repoUrl := fmt.Sprintf("https://%s/%s/%s.git", gitP1Fqdn, giteaBaseNs, repo1)
 		By("creating the RemoteSyncer")
 		remotesyncer := &syngit.RemoteSyncer{
 			ObjectMeta: metav1.ObjectMeta{
@@ -280,8 +281,8 @@ var _ = Describe("04 Create RemoteSyncer with excluded fields", func() {
 		Wait3()
 		repo := &Repo{
 			Fqdn:  gitP1Fqdn,
-			Owner: "syngituser",
-			Name:  "blue",
+			Owner: giteaBaseNs,
+			Name:  repo1,
 		}
 		uidExists, err := IsFieldDefined(*repo, cm, "metadata.uid")
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/syngit/05_defaultuser_test.go
+++ b/test/e2e/syngit/05_defaultuser_test.go
@@ -18,6 +18,7 @@ package e2e_syngit
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -84,7 +85,7 @@ var _ = Describe("05 Use a default user", func() {
 			return err == nil
 		}, timeout, interval).Should(BeTrue())
 
-		repoUrl := "https://" + gitP1Fqdn + "/syngituser/green.git"
+		repoUrl := fmt.Sprintf("https://%s/%s/%s.git", gitP1Fqdn, giteaBaseNs, repo2)
 		By("creating the default RemoteTarget")
 		remoteTarget := &syngit.RemoteTarget{
 			ObjectMeta: metav1.ObjectMeta{
@@ -146,7 +147,7 @@ var _ = Describe("05 Use a default user", func() {
 			return err == nil
 		}, timeout, interval).Should(BeTrue())
 
-		By("creating a test configmap that fails (Chopper does not have access to green)")
+		By("creating a test configmap that fails (Chopper does not have access to repo2)")
 		Wait3()
 		cm := &corev1.ConfigMap{
 			TypeMeta: metav1.TypeMeta{
@@ -185,8 +186,8 @@ var _ = Describe("05 Use a default user", func() {
 		Wait3()
 		repo := &Repo{
 			Fqdn:  gitP1Fqdn,
-			Owner: "syngituser",
-			Name:  "green",
+			Owner: giteaBaseNs,
+			Name:  repo2,
 		}
 		exists, err := IsObjectInRepo(*repo, cm)
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/syngit/06_objects_lifecycle_test.go
+++ b/test/e2e/syngit/06_objects_lifecycle_test.go
@@ -177,7 +177,7 @@ var _ = Describe("06 Test objects lifecycle", func() {
 			return err == nil
 		}, timeout, interval).Should(BeTrue())
 
-		repoUrl := "https://" + gitP1Fqdn + "/syngituser/blue.git"
+		repoUrl := fmt.Sprintf("https://%s/%s/%s.git", gitP1Fqdn, giteaBaseNs, repo1)
 		By("creating the RemoteSyncer")
 		remotesyncer := &syngit.RemoteSyncer{
 			ObjectMeta: metav1.ObjectMeta{
@@ -215,7 +215,7 @@ var _ = Describe("06 Test objects lifecycle", func() {
 			return err == nil
 		}, timeout, interval).Should(BeTrue())
 
-		By("checking that the ValidationWebhhok scopes sts")
+		By("checking that the ValidationWebhook scopes sts")
 		Wait3()
 		nnValidation := types.NamespacedName{
 			Name: dynamicWebhookName,
@@ -223,7 +223,7 @@ var _ = Describe("06 Test objects lifecycle", func() {
 		getValidation := &admissionv1.ValidatingWebhookConfiguration{}
 
 		Eventually(func() bool {
-			err := sClient.As(Luffy).Get(nnValidation, getValidation)
+			err := sClient.As(Admin).Get(nnValidation, getValidation)
 			return err == nil
 		}, timeout, interval).Should(BeTrue())
 

--- a/test/e2e/syngit/07_bypass_subject_test.go
+++ b/test/e2e/syngit/07_bypass_subject_test.go
@@ -18,6 +18,7 @@ package e2e_syngit
 
 import (
 	"context"
+	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -67,7 +68,7 @@ var _ = Describe("07 Subject bypasses interception", func() {
 			return err == nil
 		}, timeout, interval).Should(BeTrue())
 
-		repoUrl := "https://" + gitP1Fqdn + "/syngituser/blue.git"
+		repoUrl := fmt.Sprintf("https://%s/%s/%s.git", gitP1Fqdn, giteaBaseNs, repo1)
 		By("creating the RemoteSyncer")
 		remotesyncer := &syngit.RemoteSyncer{
 			ObjectMeta: metav1.ObjectMeta{
@@ -132,8 +133,8 @@ var _ = Describe("07 Subject bypasses interception", func() {
 		Wait3()
 		repo := &Repo{
 			Fqdn:  gitP1Fqdn,
-			Owner: "syngituser",
-			Name:  "blue",
+			Owner: giteaBaseNs,
+			Name:  repo1,
 		}
 		exists, err := IsObjectInRepo(*repo, cm)
 		Expect(err).To(HaveOccurred())
@@ -180,7 +181,7 @@ var _ = Describe("07 Subject bypasses interception", func() {
 			return err == nil
 		}, timeout, interval).Should(BeTrue())
 
-		repoUrl := "https://" + gitP1Fqdn + "/syngituser/blue.git"
+		repoUrl := fmt.Sprintf("https://%s/%s/%s.git", gitP1Fqdn, giteaBaseNs, repo1)
 		By("creating the RemoteSyncer")
 		remotesyncer := &syngit.RemoteSyncer{
 			ObjectMeta: metav1.ObjectMeta{
@@ -245,8 +246,8 @@ var _ = Describe("07 Subject bypasses interception", func() {
 		Wait3()
 		repo := &Repo{
 			Fqdn:  gitP1Fqdn,
-			Owner: "syngituser",
-			Name:  "blue",
+			Owner: giteaBaseNs,
+			Name:  repo1,
 		}
 		exists, err := IsObjectInRepo(*repo, cm)
 		Expect(err).To(HaveOccurred())

--- a/test/e2e/syngit/09_multi_remotesyncer_test.go
+++ b/test/e2e/syngit/09_multi_remotesyncer_test.go
@@ -18,6 +18,7 @@ package e2e_syngit
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -67,9 +68,9 @@ var _ = Describe("09 Multi RemoteSyncer test", func() {
 			return err == nil
 		}, timeout, interval).Should(BeTrue())
 
-		blueUrl := "https://" + gitP1Fqdn + "/syngituser/blue.git"
-		By("creating the RemoteSyncer for the blue repo")
-		blueRemotesyncer := &syngit.RemoteSyncer{
+		repo1Url := fmt.Sprintf("https://%s/%s/%s.git", gitP1Fqdn, giteaBaseNs, repo1)
+		By("creating the RemoteSyncer for the repo1")
+		repo1Remotesyncer := &syngit.RemoteSyncer{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      remoteSyncer1Name,
 				Namespace: namespace,
@@ -84,7 +85,7 @@ var _ = Describe("09 Multi RemoteSyncer test", func() {
 				ExcludedFields:              []string{".metadata.uid"},
 				Strategy:                    syngit.CommitApply,
 				TargetStrategy:              syngit.OneTarget,
-				RemoteRepository:            blueUrl,
+				RemoteRepository:            repo1Url,
 				ScopedResources: syngit.ScopedResources{
 					Rules: []admissionv1.RuleWithOperations{{
 						Operations: []admissionv1.OperationType{
@@ -100,12 +101,12 @@ var _ = Describe("09 Multi RemoteSyncer test", func() {
 				},
 			},
 		}
-		err := sClient.As(Luffy).CreateOrUpdate(blueRemotesyncer)
+		err := sClient.As(Luffy).CreateOrUpdate(repo1Remotesyncer)
 		Expect(err).ToNot(HaveOccurred())
 
-		greenUrl := "https://" + gitP1Fqdn + "/syngituser/green.git"
-		By("creating the RemoteSyncer for the green repo")
-		greenRemotesyncer := &syngit.RemoteSyncer{
+		repo2Url := fmt.Sprintf("https://%s/%s/%s.git", gitP1Fqdn, giteaBaseNs, repo2)
+		By("creating the RemoteSyncer for the repo2")
+		repo2Remotesyncer := &syngit.RemoteSyncer{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      remoteSyncer2Name,
 				Namespace: namespace,
@@ -120,7 +121,7 @@ var _ = Describe("09 Multi RemoteSyncer test", func() {
 				ExcludedFields:              []string{".metadata.uid"},
 				Strategy:                    syngit.CommitApply,
 				TargetStrategy:              syngit.OneTarget,
-				RemoteRepository:            greenUrl,
+				RemoteRepository:            repo2Url,
 				ScopedResources: syngit.ScopedResources{
 					Rules: []admissionv1.RuleWithOperations{{
 						Operations: []admissionv1.OperationType{
@@ -136,7 +137,7 @@ var _ = Describe("09 Multi RemoteSyncer test", func() {
 				},
 			},
 		}
-		err = sClient.As(Luffy).CreateOrUpdate(greenRemotesyncer)
+		err = sClient.As(Luffy).CreateOrUpdate(repo2Remotesyncer)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("creating a test configmap")
@@ -157,24 +158,24 @@ var _ = Describe("09 Multi RemoteSyncer test", func() {
 			return err == nil
 		}, timeout, interval).Should(BeTrue())
 
-		By("checking that the configmap is present in the blue repo")
+		By("checking that the configmap is present in the repo1")
 		Wait3()
-		blueRepo := &Repo{
+		repo1Repo := &Repo{
 			Fqdn:  gitP1Fqdn,
-			Owner: "syngituser",
-			Name:  "blue",
+			Owner: giteaBaseNs,
+			Name:  repo1,
 		}
-		exists, err := IsObjectInRepo(*blueRepo, cm)
+		exists, err := IsObjectInRepo(*repo1Repo, cm)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(exists).To(BeTrue())
 
-		By("checking that the configmap is present in the green repo")
-		greenRepo := &Repo{
+		By("checking that the configmap is present in the repo2")
+		repo2Repo := &Repo{
 			Fqdn:  gitP1Fqdn,
-			Owner: "syngituser",
-			Name:  "green",
+			Owner: giteaBaseNs,
+			Name:  repo2,
 		}
-		exists, err = IsObjectInRepo(*greenRepo, cm)
+		exists, err = IsObjectInRepo(*repo2Repo, cm)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(exists).To(BeTrue())
 
@@ -217,9 +218,9 @@ var _ = Describe("09 Multi RemoteSyncer test", func() {
 			return err == nil
 		}, timeout, interval).Should(BeTrue())
 
-		blueUrl := "https://" + gitP1Fqdn + "/syngituser/blue.git"
-		By("creating the RemoteSyncer for the blue repo")
-		blueRemotesyncer := &syngit.RemoteSyncer{
+		repo1Url := fmt.Sprintf("https://%s/%s/%s.git", gitP1Fqdn, giteaBaseNs, repo1)
+		By("creating the RemoteSyncer for the repo1")
+		repo1Remotesyncer := &syngit.RemoteSyncer{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      remoteSyncer1Name,
 				Namespace: namespace,
@@ -234,7 +235,7 @@ var _ = Describe("09 Multi RemoteSyncer test", func() {
 				ExcludedFields:              []string{".metadata.uid"},
 				Strategy:                    syngit.CommitApply,
 				TargetStrategy:              syngit.OneTarget,
-				RemoteRepository:            blueUrl,
+				RemoteRepository:            repo1Url,
 				ScopedResources: syngit.ScopedResources{
 					Rules: []admissionv1.RuleWithOperations{{
 						Operations: []admissionv1.OperationType{
@@ -250,11 +251,11 @@ var _ = Describe("09 Multi RemoteSyncer test", func() {
 				},
 			},
 		}
-		err := sClient.As(Luffy).CreateOrUpdate(blueRemotesyncer)
+		err := sClient.As(Luffy).CreateOrUpdate(repo1Remotesyncer)
 		Expect(err).ToNot(HaveOccurred())
 
-		By("creating the RemoteSyncer for the blue repo twice")
-		blueRemotesyncer2 := &syngit.RemoteSyncer{
+		By("creating the RemoteSyncer for the repo1 twice")
+		repo1Remotesyncer2 := &syngit.RemoteSyncer{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      remoteSyncer2Name,
 				Namespace: namespace,
@@ -269,7 +270,7 @@ var _ = Describe("09 Multi RemoteSyncer test", func() {
 				ExcludedFields:              []string{".metadata.uid"},
 				Strategy:                    syngit.CommitApply,
 				TargetStrategy:              syngit.OneTarget,
-				RemoteRepository:            blueUrl,
+				RemoteRepository:            repo1Url,
 				ScopedResources: syngit.ScopedResources{
 					Rules: []admissionv1.RuleWithOperations{{
 						Operations: []admissionv1.OperationType{
@@ -285,7 +286,7 @@ var _ = Describe("09 Multi RemoteSyncer test", func() {
 				},
 			},
 		}
-		err = sClient.As(Luffy).CreateOrUpdate(blueRemotesyncer2)
+		err = sClient.As(Luffy).CreateOrUpdate(repo1Remotesyncer2)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("creating a test configmap")
@@ -306,14 +307,14 @@ var _ = Describe("09 Multi RemoteSyncer test", func() {
 			return err != nil && strings.Contains(err.Error(), "cannot lock ref")
 		}, timeout, interval).Should(BeTrue())
 
-		By("checking that the configmap is not present in the blue repo")
+		By("checking that the configmap is not present in the repo1")
 		Wait3()
-		blueRepo := &Repo{
+		repo1Repo := &Repo{
 			Fqdn:  gitP1Fqdn,
-			Owner: "syngituser",
-			Name:  "blue",
+			Owner: giteaBaseNs,
+			Name:  repo1,
 		}
-		exists, err := IsObjectInRepo(*blueRepo, cm)
+		exists, err := IsObjectInRepo(*repo1Repo, cm)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(exists).To(BeTrue())
 

--- a/test/e2e/syngit/10_remoteuser_secret_access_test.go
+++ b/test/e2e/syngit/10_remoteuser_secret_access_test.go
@@ -17,11 +17,10 @@ limitations under the License.
 package e2e_syngit
 
 import (
-	"strings"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	syngit "github.com/syngit-org/syngit/pkg/api/v1beta3"
+	"github.com/syngit-org/syngit/pkg/utils"
 	. "github.com/syngit-org/syngit/test/utils"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -52,7 +51,7 @@ var _ = Describe("10 RemoteUser secret permissions checker", func() {
 		}
 		Eventually(func() bool {
 			err := sClient.As(Brook).CreateOrUpdate(remoteUserBrook)
-			return err != nil && strings.Contains(err.Error(), ruPermissionsDeniedMessage)
+			return err != nil && utils.ErrorTypeChecker(&utils.DenyGetSecretError{}, err.Error())
 		}, timeout, interval).Should(BeTrue())
 
 	})

--- a/test/e2e/syngit/11_remoteuserbinding_permissions_test.go
+++ b/test/e2e/syngit/11_remoteuserbinding_permissions_test.go
@@ -17,11 +17,10 @@ limitations under the License.
 package e2e_syngit
 
 import (
-	"strings"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	syngit "github.com/syngit-org/syngit/pkg/api/v1beta3"
+	"github.com/syngit-org/syngit/pkg/utils"
 	. "github.com/syngit-org/syngit/test/utils"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -72,7 +71,7 @@ var _ = Describe("11 RemoteUserBinding permissions checker", func() {
 		}
 		Eventually(func() bool {
 			err := sClient.As(Brook).CreateOrUpdate(remoteUserBindingBrook)
-			return err != nil && strings.Contains(err.Error(), rubPermissionsDeniedMessage)
+			return err != nil && utils.ErrorTypeChecker(&utils.DenyGetRemoteUserError{}, err.Error())
 		}, timeout, interval).Should(BeTrue())
 
 	})

--- a/test/e2e/syngit/13_remotesyncer_tls_test.go
+++ b/test/e2e/syngit/13_remotesyncer_tls_test.go
@@ -18,6 +18,7 @@ package e2e_syngit
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strings"
 
@@ -96,7 +97,7 @@ var _ = Describe("13 RemoteSyncer TLS insecure & custom CA bundle test", func() 
 			return err == nil
 		}, timeout, interval).Should(BeTrue())
 
-		repoUrl := "https://" + gitP1Fqdn + "/syngituser/green.git"
+		repoUrl := fmt.Sprintf("https://%s/%s/%s.git", gitP1Fqdn, giteaBaseNs, repo2)
 		By("creating the RemoteSyncer")
 		remotesyncer := &syngit.RemoteSyncer{
 			ObjectMeta: metav1.ObjectMeta{
@@ -158,8 +159,8 @@ var _ = Describe("13 RemoteSyncer TLS insecure & custom CA bundle test", func() 
 		Wait3()
 		repo := &Repo{
 			Fqdn:  gitP1Fqdn,
-			Owner: "syngituser",
-			Name:  "green",
+			Owner: giteaBaseNs,
+			Name:  repo2,
 		}
 		exists, err := IsObjectInRepo(*repo, cm)
 		Expect(err).ToNot(HaveOccurred())
@@ -224,7 +225,7 @@ var _ = Describe("13 RemoteSyncer TLS insecure & custom CA bundle test", func() 
 			return err == nil
 		}, timeout, interval).Should(BeTrue())
 
-		repoUrl := "https://" + gitP1Fqdn + "/syngituser/green.git"
+		repoUrl := fmt.Sprintf("https://%s/%s/%s.git", gitP1Fqdn, giteaBaseNs, repo2)
 		By("creating the RemoteSyncer")
 		remotesyncer := &syngit.RemoteSyncer{
 			ObjectMeta: metav1.ObjectMeta{
@@ -287,8 +288,8 @@ var _ = Describe("13 RemoteSyncer TLS insecure & custom CA bundle test", func() 
 		Wait3()
 		repo := &Repo{
 			Fqdn:  gitP1Fqdn,
-			Owner: "syngituser",
-			Name:  "green",
+			Owner: giteaBaseNs,
+			Name:  repo2,
 		}
 		exists, err := IsObjectInRepo(*repo, cm)
 		Expect(err).ToNot(HaveOccurred())
@@ -324,7 +325,7 @@ var _ = Describe("13 RemoteSyncer TLS insecure & custom CA bundle test", func() 
 			Type: "kubernetes.io/tls",
 		}
 		Eventually(func() bool {
-			_, err = sClient.KAs(Luffy).CoreV1().Secrets(operatorNamespace).Create(ctx,
+			_, err = sClient.KAs(Admin).CoreV1().Secrets(operatorNamespace).Create(ctx,
 				secretCreds,
 				metav1.CreateOptions{},
 			)
@@ -354,7 +355,7 @@ var _ = Describe("13 RemoteSyncer TLS insecure & custom CA bundle test", func() 
 			return err == nil
 		}, timeout, interval).Should(BeTrue())
 
-		repoUrl := "https://" + gitP1Fqdn + "/syngituser/green.git"
+		repoUrl := fmt.Sprintf("https://%s/%s/%s.git", gitP1Fqdn, giteaBaseNs, repo2)
 		By("creating the RemoteSyncer")
 		remotesyncer := &syngit.RemoteSyncer{
 			ObjectMeta: metav1.ObjectMeta{
@@ -413,8 +414,8 @@ var _ = Describe("13 RemoteSyncer TLS insecure & custom CA bundle test", func() 
 		Wait3()
 		repo := &Repo{
 			Fqdn:  gitP1Fqdn,
-			Owner: "syngituser",
-			Name:  "green",
+			Owner: giteaBaseNs,
+			Name:  repo2,
 		}
 		exists, err := IsObjectInRepo(*repo, cm)
 		Expect(err).ToNot(HaveOccurred())
@@ -434,7 +435,7 @@ var _ = Describe("13 RemoteSyncer TLS insecure & custom CA bundle test", func() 
 
 		By("deleting the ca bundle secret in the same namespace using the host as name")
 		Eventually(func() bool {
-			err = sClient.KAs(Luffy).CoreV1().Secrets(operatorNamespace).Delete(ctx,
+			err = sClient.KAs(Admin).CoreV1().Secrets(operatorNamespace).Delete(ctx,
 				caBundleName,
 				metav1.DeleteOptions{},
 			)
@@ -466,7 +467,7 @@ var _ = Describe("13 RemoteSyncer TLS insecure & custom CA bundle test", func() 
 			return err == nil
 		}, timeout, interval).Should(BeTrue())
 
-		repoUrl := "https://" + gitP1Fqdn + "/syngituser/green.git"
+		repoUrl := fmt.Sprintf("https://%s/%s/%s.git", gitP1Fqdn, giteaBaseNs, repo2)
 		By("creating the RemoteSyncer")
 		remotesyncer := &syngit.RemoteSyncer{
 			ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/syngit/14_remoteuserbinding_cross_user_test.go
+++ b/test/e2e/syngit/14_remoteuserbinding_cross_user_test.go
@@ -17,11 +17,10 @@ limitations under the License.
 package e2e_syngit
 
 import (
-	"strings"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	syngit "github.com/syngit-org/syngit/pkg/api/v1beta3"
+	"github.com/syngit-org/syngit/pkg/utils"
 	. "github.com/syngit-org/syngit/test/utils"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -89,7 +88,7 @@ var _ = Describe("14 RemoteUser RBAC cross user test", func() {
 		}
 		Eventually(func() bool {
 			err := sClient.As(Luffy).CreateOrUpdate(remoteUserChopperWithNoAssociatedRub)
-			return err != nil && strings.Contains(err.Error(), crossRubErrorMessage)
+			return err != nil && utils.ErrorTypeChecker(&utils.RemoteUserAlreadyBoundError{}, err.Error())
 		}, timeout, interval).Should(BeTrue())
 
 		By("modifying removing Chopper rub annotation using Chopper")

--- a/test/e2e/syngit/16_wrong_reference_value_test.go
+++ b/test/e2e/syngit/16_wrong_reference_value_test.go
@@ -18,11 +18,13 @@ package e2e_syngit
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	syngit "github.com/syngit-org/syngit/pkg/api/v1beta3"
+	"github.com/syngit-org/syngit/pkg/utils"
 	. "github.com/syngit-org/syngit/test/utils"
 	admissionv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -98,7 +100,7 @@ var _ = Describe("16 Wrong reference or value test", func() {
 			return err == nil
 		}, timeout, interval).Should(BeTrue())
 
-		repoUrl := "https://" + gitP1Fqdn + "/syngituser/blue.git"
+		repoUrl := fmt.Sprintf("https://%s/%s/%s.git", gitP1Fqdn, giteaBaseNs, repo1)
 		By("creating the RemoteSyncer")
 		remotesyncer := &syngit.RemoteSyncer{
 			ObjectMeta: metav1.ObjectMeta{
@@ -151,15 +153,15 @@ var _ = Describe("16 Wrong reference or value test", func() {
 				cm,
 				metav1.CreateOptions{},
 			)
-			return err != nil && strings.Contains(err.Error(), rubNotFound)
+			return err != nil && utils.ErrorTypeChecker(&utils.RemoteUserBindingNotFoundError{}, err.Error())
 		}, timeout, interval).Should(BeTrue())
 
 		By("checking that the configmap is not present on the repo")
 		Wait3()
 		repo := &Repo{
 			Fqdn:  gitP1Fqdn,
-			Owner: "syngituser",
-			Name:  "blue",
+			Owner: giteaBaseNs,
+			Name:  repo1,
 		}
 		exists, err := IsObjectInRepo(*repo, cm)
 		Expect(err).To(HaveOccurred())
@@ -226,7 +228,7 @@ var _ = Describe("16 Wrong reference or value test", func() {
 				cm,
 				metav1.CreateOptions{},
 			)
-			return err != nil && strings.Contains(err.Error(), defaultUserNotFound)
+			return err != nil && utils.ErrorTypeChecker(&utils.DefaultRemoteUserNotFoundError{}, err.Error())
 		}, timeout, interval).Should(BeTrue())
 
 		By("checking that the configmap is not present on the repo")
@@ -312,7 +314,7 @@ var _ = Describe("16 Wrong reference or value test", func() {
 				cm,
 				metav1.CreateOptions{},
 			)
-			return err != nil && strings.Contains(err.Error(), defaultTargetNotFound)
+			return err != nil && utils.ErrorTypeChecker(&utils.DefaultRemoteTargetNotFoundError{}, err.Error())
 		}, timeout, interval).Should(BeTrue())
 
 		By("checking that the configmap is not present on the repo")

--- a/test/e2e/syngit/17_remoteuserbinding_selector_test.go
+++ b/test/e2e/syngit/17_remoteuserbinding_selector_test.go
@@ -24,6 +24,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	syngit "github.com/syngit-org/syngit/pkg/api/v1beta3"
+	"github.com/syngit-org/syngit/pkg/utils"
 	. "github.com/syngit-org/syngit/test/utils"
 	admissionv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -48,7 +49,7 @@ var _ = Describe("17 RemoteUserBinding selector in RemoteSyncer", func() {
 		branch                     = "main"
 	)
 
-	remoteTargetName := fmt.Sprintf("%s-syngituser-blue-%s-syngituser-blue-%s", syngit.RtPrefix, branch, branch)
+	remoteTargetName := fmt.Sprintf("%s-%s-%s-%s-%s-%s-%s", syngit.RtPrefix, giteaBaseNs, repo1, branch, giteaBaseNs, repo1, branch)
 
 	It("should not push because RemoteUserBinding not targeted", func() {
 		By("creating the RemoteUser & RemoteUserBinding for Luffy")
@@ -105,7 +106,7 @@ var _ = Describe("17 RemoteUserBinding selector in RemoteSyncer", func() {
 			return err == nil
 		}, timeout, interval).Should(BeTrue())
 
-		repoUrl := "https://" + gitP1Fqdn + "/syngituser/blue.git"
+		repoUrl := fmt.Sprintf("https://%s/%s/%s.git", gitP1Fqdn, giteaBaseNs, repo1)
 		By("creating the RemoteSyncer")
 		remotesyncer := &syngit.RemoteSyncer{
 			ObjectMeta: metav1.ObjectMeta{
@@ -162,15 +163,15 @@ var _ = Describe("17 RemoteUserBinding selector in RemoteSyncer", func() {
 				cm,
 				metav1.CreateOptions{},
 			)
-			return err != nil && strings.Contains(err.Error(), rubNotFound)
+			return err != nil && utils.ErrorTypeChecker(&utils.RemoteUserBindingNotFoundError{}, err.Error())
 		}, timeout, interval).Should(BeTrue())
 
 		By("checking that the configmap is not present on the repo")
 		Wait3()
 		repo := &Repo{
 			Fqdn:  gitP1Fqdn,
-			Owner: "syngituser",
-			Name:  "blue",
+			Owner: giteaBaseNs,
+			Name:  repo1,
 		}
 		exists, err := IsObjectInRepo(*repo, cm)
 		Expect(err).To(HaveOccurred())
@@ -244,7 +245,7 @@ var _ = Describe("17 RemoteUserBinding selector in RemoteSyncer", func() {
 			return err == nil
 		}, timeout, interval).Should(BeTrue())
 
-		repoUrl := "https://" + gitP1Fqdn + "/syngituser/blue.git"
+		repoUrl := fmt.Sprintf("https://%s/%s/%s.git", gitP1Fqdn, giteaBaseNs, repo1)
 		By("creating the RemoteSyncer")
 		remotesyncer := &syngit.RemoteSyncer{
 			ObjectMeta: metav1.ObjectMeta{
@@ -308,8 +309,8 @@ var _ = Describe("17 RemoteUserBinding selector in RemoteSyncer", func() {
 		Wait3()
 		repo := &Repo{
 			Fqdn:  gitP1Fqdn,
-			Owner: "syngituser",
-			Name:  "blue",
+			Owner: giteaBaseNs,
+			Name:  repo1,
 		}
 		exists, err := IsObjectInRepo(*repo, cm)
 		Expect(err).ToNot(HaveOccurred())
@@ -388,7 +389,7 @@ var _ = Describe("17 RemoteUserBinding selector in RemoteSyncer", func() {
 			return err == nil
 		}, timeout, interval).Should(BeTrue())
 
-		repoUrl := "https://" + gitP1Fqdn + "/syngituser/blue.git"
+		repoUrl := fmt.Sprintf("https://%s/%s/%s.git", gitP1Fqdn, giteaBaseNs, repo1)
 		By("creating the RemoteSyncer")
 		remotesyncer := &syngit.RemoteSyncer{
 			ObjectMeta: metav1.ObjectMeta{
@@ -449,8 +450,8 @@ var _ = Describe("17 RemoteUserBinding selector in RemoteSyncer", func() {
 		Wait3()
 		repo := &Repo{
 			Fqdn:  gitP1Fqdn,
-			Owner: "syngituser",
-			Name:  "blue",
+			Owner: giteaBaseNs,
+			Name:  repo1,
 		}
 		exists, err := IsObjectInRepo(*repo, cm)
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/syngit/18_cluster_default_excludedfields_test.go
+++ b/test/e2e/syngit/18_cluster_default_excludedfields_test.go
@@ -18,6 +18,7 @@ package e2e_syngit
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -82,13 +83,13 @@ var _ = Describe("18 Cluster default excluded fields test", func() {
 				"excludedFields": "[\"metadata.uid\", \"metadata.managedFields\", \"metadata.annotations[test-annotation1]\", \"metadata.annotations.[test-annotation2]\"]",
 			},
 		}
-		_, err := sClient.KAs(Luffy).CoreV1().ConfigMaps(operatorNamespace).Create(ctx,
+		_, err := sClient.KAs(Admin).CoreV1().ConfigMaps(operatorNamespace).Create(ctx,
 			excludedFieldsConfiMap,
 			metav1.CreateOptions{},
 		)
 		Expect(err).ToNot(HaveOccurred())
 
-		repoUrl := "https://" + gitP1Fqdn + "/syngituser/blue.git"
+		repoUrl := fmt.Sprintf("https://%s/%s/%s.git", gitP1Fqdn, giteaBaseNs, repo1)
 		By("creating the RemoteSyncer")
 		remotesyncer := &syngit.RemoteSyncer{
 			ObjectMeta: metav1.ObjectMeta{
@@ -155,8 +156,8 @@ var _ = Describe("18 Cluster default excluded fields test", func() {
 		Wait3()
 		repo := &Repo{
 			Fqdn:  gitP1Fqdn,
-			Owner: "syngituser",
-			Name:  "blue",
+			Owner: giteaBaseNs,
+			Name:  repo1,
 		}
 		uidExists, err := IsFieldDefined(*repo, cm, "metadata.uid")
 		Expect(err).ToNot(HaveOccurred())
@@ -182,7 +183,7 @@ var _ = Describe("18 Cluster default excluded fields test", func() {
 		Expect(annotation3).To(Equal("test"))
 
 		By("deleting the default cluster wide excluded fields configmap")
-		err = sClient.KAs(Luffy).CoreV1().ConfigMaps(operatorNamespace).Delete(ctx,
+		err = sClient.KAs(Admin).CoreV1().ConfigMaps(operatorNamespace).Delete(ctx,
 			excludedFieldsConfiMapName,
 			metav1.DeleteOptions{},
 		)

--- a/test/e2e/syngit/20_objects_without_annotations_test.go
+++ b/test/e2e/syngit/20_objects_without_annotations_test.go
@@ -18,6 +18,7 @@ package e2e_syngit
 
 import (
 	"context"
+	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -44,7 +45,7 @@ var _ = Describe("20 All syngit objects without annotations test", func() {
 
 	It("should process the all workflow by creating the ConfigMap", func() {
 
-		repoUrl := "https://" + gitP1Fqdn + "/syngituser/blue.git"
+		repoUrl := fmt.Sprintf("https://%s/%s/%s.git", gitP1Fqdn, giteaBaseNs, repo1)
 
 		By("creating the RemoteUser for Luffy")
 		luffySecretName := string(Luffy) + "-creds"
@@ -167,8 +168,8 @@ var _ = Describe("20 All syngit objects without annotations test", func() {
 		Wait3()
 		repo := &Repo{
 			Fqdn:  gitP1Fqdn,
-			Owner: "syngituser",
-			Name:  "blue",
+			Owner: giteaBaseNs,
+			Name:  repo1,
 		}
 		exists, err := IsObjectInRepo(*repo, cm)
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/syngit/21_remotetarget_one_different_branch_test.go
+++ b/test/e2e/syngit/21_remotetarget_one_different_branch_test.go
@@ -18,6 +18,7 @@ package e2e_syngit
 
 import (
 	"context"
+	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -44,7 +45,7 @@ var _ = Describe("21 RemoteTarget one different branch", func() {
 
 	It("should push the ConfigMap to the Luffy branch (using one strategy)", func() {
 
-		repoUrl := "https://" + gitP1Fqdn + "/syngituser/blue.git"
+		repoUrl := fmt.Sprintf("https://%s/%s/%s.git", gitP1Fqdn, giteaBaseNs, repo1)
 		targetBranch := string(Luffy)
 
 		By("creating the RemoteUser & RemoteUserBinding for Luffy")
@@ -128,8 +129,8 @@ var _ = Describe("21 RemoteTarget one different branch", func() {
 		Wait3()
 		repo := &Repo{
 			Fqdn:   gitP1Fqdn,
-			Owner:  "syngituser",
-			Name:   "blue",
+			Owner:  giteaBaseNs,
+			Name:   repo1,
 			Branch: targetBranch,
 		}
 		exists, err := IsObjectInRepo(*repo, cm)
@@ -152,7 +153,7 @@ var _ = Describe("21 RemoteTarget one different branch", func() {
 
 	It("should push the ConfigMap to the second-branch branch (using multiple strategy)", func() {
 
-		repoUrl := "https://" + gitP1Fqdn + "/syngituser/blue.git"
+		repoUrl := fmt.Sprintf("https://%s/%s/%s.git", gitP1Fqdn, giteaBaseNs, repo1)
 
 		By("creating the RemoteUser for Luffy")
 		luffySecretName := string(Luffy) + "-creds"
@@ -235,8 +236,8 @@ var _ = Describe("21 RemoteTarget one different branch", func() {
 		Wait3()
 		repo := &Repo{
 			Fqdn:   gitP1Fqdn,
-			Owner:  "syngituser",
-			Name:   "blue",
+			Owner:  giteaBaseNs,
+			Name:   repo1,
 			Branch: customBranch,
 		}
 		exists, err := IsObjectInRepo(*repo, cm)

--- a/test/e2e/syngit/22_remotetarget_multiple_different_branch_test.go
+++ b/test/e2e/syngit/22_remotetarget_multiple_different_branch_test.go
@@ -18,11 +18,13 @@ package e2e_syngit
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	syngit "github.com/syngit-org/syngit/pkg/api/v1beta3"
+	"github.com/syngit-org/syngit/pkg/utils"
 	. "github.com/syngit-org/syngit/test/utils"
 	admissionv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -47,7 +49,7 @@ var _ = Describe("22 RemoteTarget multiple different branch", func() {
 
 	It("should push the ConfigMap to all the branches and the Luffy's branch", func() {
 
-		repoUrl := "https://" + gitP1Fqdn + "/syngituser/blue.git"
+		repoUrl := fmt.Sprintf("https://%s/%s/%s.git", gitP1Fqdn, giteaBaseNs, repo1)
 		targetBranch := string(Luffy)
 
 		By("creating the RemoteUser for Luffy")
@@ -133,8 +135,8 @@ var _ = Describe("22 RemoteTarget multiple different branch", func() {
 		Wait3()
 		repo := &Repo{
 			Fqdn:   gitP1Fqdn,
-			Owner:  "syngituser",
-			Name:   "blue",
+			Owner:  giteaBaseNs,
+			Name:   repo1,
 			Branch: targetBranch,
 		}
 		exists, err := IsObjectInRepo(*repo, cm)
@@ -143,8 +145,8 @@ var _ = Describe("22 RemoteTarget multiple different branch", func() {
 		for _, branch := range branches {
 			repo := &Repo{
 				Fqdn:   gitP1Fqdn,
-				Owner:  "syngituser",
-				Name:   "blue",
+				Owner:  giteaBaseNs,
+				Name:   repo1,
 				Branch: branch,
 			}
 			exists, err := IsObjectInRepo(*repo, cm)
@@ -168,7 +170,7 @@ var _ = Describe("22 RemoteTarget multiple different branch", func() {
 
 	It("should deny the request because of the wrong strategy", func() {
 
-		repoUrl := "https://" + gitP1Fqdn + "/syngituser/blue.git"
+		repoUrl := fmt.Sprintf("https://%s/%s/%s.git", gitP1Fqdn, giteaBaseNs, repo1)
 		targetBranch := string(Luffy)
 
 		By("creating the RemoteUser for Luffy")
@@ -247,15 +249,15 @@ var _ = Describe("22 RemoteTarget multiple different branch", func() {
 				cm,
 				metav1.CreateOptions{},
 			)
-			return err != nil && strings.Contains(err.Error(), oneTargetForMultipleMessage)
+			return err != nil && utils.ErrorTypeChecker(&utils.MultipleTargetError{}, err.Error())
 		}, timeout, interval).Should(BeTrue())
 
 		By("checking that the configmap is not present on the branches")
 		Wait3()
 		repo := &Repo{
 			Fqdn:   gitP1Fqdn,
-			Owner:  "syngituser",
-			Name:   "blue",
+			Owner:  giteaBaseNs,
+			Name:   repo1,
 			Branch: targetBranch,
 		}
 		exists, err := IsObjectInRepo(*repo, cm)
@@ -264,8 +266,8 @@ var _ = Describe("22 RemoteTarget multiple different branch", func() {
 		for _, branch := range branches {
 			repo := &Repo{
 				Fqdn:   gitP1Fqdn,
-				Owner:  "syngituser",
-				Name:   "blue",
+				Owner:  giteaBaseNs,
+				Name:   repo1,
 				Branch: branch,
 			}
 			exists, err := IsObjectInRepo(*repo, cm)

--- a/test/e2e/syngit/23_remotetarger_selector._test.go
+++ b/test/e2e/syngit/23_remotetarger_selector._test.go
@@ -18,11 +18,13 @@ package e2e_syngit
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	syngit "github.com/syngit-org/syngit/pkg/api/v1beta3"
+	"github.com/syngit-org/syngit/pkg/utils"
 	. "github.com/syngit-org/syngit/test/utils"
 	admissionv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -78,7 +80,7 @@ var _ = Describe("23 RemoteTarget selector in RemoteSyncer", func() {
 			return err == nil
 		}, timeout, interval).Should(BeTrue())
 
-		repoUrl := "https://" + gitP1Fqdn + "/syngituser/blue.git"
+		repoUrl := fmt.Sprintf("https://%s/%s/%s.git", gitP1Fqdn, giteaBaseNs, repo1)
 		By("creating a RemoteTarget")
 		const (
 			myLabelKey   = "my-label-key"
@@ -183,15 +185,15 @@ var _ = Describe("23 RemoteTarget selector in RemoteSyncer", func() {
 				cm,
 				metav1.CreateOptions{},
 			)
-			return err != nil && strings.Contains(err.Error(), rtNotFound)
+			return err != nil && utils.ErrorTypeChecker(&utils.RemoteTargetNotFoundError{}, err.Error())
 		}, timeout, interval).Should(BeTrue())
 
 		By("checking that the configmap is not present on the repo")
 		Wait3()
 		repo := &Repo{
 			Fqdn:   gitP1Fqdn,
-			Owner:  "syngituser",
-			Name:   "blue",
+			Owner:  giteaBaseNs,
+			Name:   repo1,
 			Branch: branch,
 		}
 		exists, err := IsObjectInRepo(*repo, cm)
@@ -232,7 +234,7 @@ var _ = Describe("23 RemoteTarget selector in RemoteSyncer", func() {
 			return err == nil
 		}, timeout, interval).Should(BeTrue())
 
-		repoUrl := "https://" + gitP1Fqdn + "/syngituser/blue.git"
+		repoUrl := fmt.Sprintf("https://%s/%s/%s.git", gitP1Fqdn, giteaBaseNs, repo1)
 		By("creating a RemoteTarget")
 		const (
 			myLabelKey   = "my-label-key"
@@ -344,8 +346,8 @@ var _ = Describe("23 RemoteTarget selector in RemoteSyncer", func() {
 		Wait3()
 		repo := &Repo{
 			Fqdn:  gitP1Fqdn,
-			Owner: "syngituser",
-			Name:  "blue",
+			Owner: giteaBaseNs,
+			Name:  repo1,
 		}
 		exists, err := IsObjectInRepo(*repo, cm)
 		Expect(err).ToNot(HaveOccurred())
@@ -390,7 +392,7 @@ var _ = Describe("23 RemoteTarget selector in RemoteSyncer", func() {
 			return err == nil
 		}, timeout, interval).Should(BeTrue())
 
-		repoUrl := "https://" + gitP1Fqdn + "/syngituser/blue.git"
+		repoUrl := fmt.Sprintf("https://%s/%s/%s.git", gitP1Fqdn, giteaBaseNs, repo1)
 		By("creating a RemoteTarget")
 		const (
 			myLabelKey   = "my-label-key"
@@ -499,8 +501,8 @@ var _ = Describe("23 RemoteTarget selector in RemoteSyncer", func() {
 		Wait3()
 		repo := &Repo{
 			Fqdn:  gitP1Fqdn,
-			Owner: "syngituser",
-			Name:  "blue",
+			Owner: giteaBaseNs,
+			Name:  repo1,
 		}
 		exists, err := IsObjectInRepo(*repo, cm)
 		Expect(err).ToNot(HaveOccurred())
@@ -545,7 +547,7 @@ var _ = Describe("23 RemoteTarget selector in RemoteSyncer", func() {
 			return err == nil
 		}, timeout, interval).Should(BeTrue())
 
-		repoUrl := "https://" + gitP1Fqdn + "/syngituser/blue.git"
+		repoUrl := fmt.Sprintf("https://%s/%s/%s.git", gitP1Fqdn, giteaBaseNs, repo1)
 		By("creating the first RemoteTarget")
 		const (
 			myLabelKey   = "my-label-key"
@@ -686,8 +688,8 @@ var _ = Describe("23 RemoteTarget selector in RemoteSyncer", func() {
 		Wait3()
 		repo := &Repo{
 			Fqdn:   gitP1Fqdn,
-			Owner:  "syngituser",
-			Name:   "blue",
+			Owner:  giteaBaseNs,
+			Name:   repo1,
 			Branch: branch1,
 		}
 		exists, err := IsObjectInRepo(*repo, cm)
@@ -695,8 +697,8 @@ var _ = Describe("23 RemoteTarget selector in RemoteSyncer", func() {
 		Expect(exists).To(BeTrue())
 		repo = &Repo{
 			Fqdn:   gitP1Fqdn,
-			Owner:  "syngituser",
-			Name:   "blue",
+			Owner:  giteaBaseNs,
+			Name:   repo1,
 			Branch: branch2,
 		}
 		exists, err = IsObjectInRepo(*repo, cm)
@@ -741,7 +743,7 @@ var _ = Describe("23 RemoteTarget selector in RemoteSyncer", func() {
 			return err == nil
 		}, timeout, interval).Should(BeTrue())
 
-		repoUrl := "https://" + gitP1Fqdn + "/syngituser/blue.git"
+		repoUrl := fmt.Sprintf("https://%s/%s/%s.git", gitP1Fqdn, giteaBaseNs, repo1)
 		By("creating a RemoteTarget")
 		const (
 			myLabelKey   = "my-label-key"
@@ -818,15 +820,15 @@ var _ = Describe("23 RemoteTarget selector in RemoteSyncer", func() {
 				cm,
 				metav1.CreateOptions{},
 			)
-			return err != nil && strings.Contains(err.Error(), rtNotFound)
+			return err != nil && utils.ErrorTypeChecker(&utils.RemoteTargetNotFoundError{}, err.Error())
 		}, timeout, interval).Should(BeTrue())
 
 		By("checking that the configmap is not present on the repo")
 		Wait3()
 		repo := &Repo{
 			Fqdn:   gitP1Fqdn,
-			Owner:  "syngituser",
-			Name:   "blue",
+			Owner:  giteaBaseNs,
+			Name:   repo1,
 			Branch: branch,
 		}
 		exists, err := IsObjectInRepo(*repo, cm)

--- a/test/e2e/syngit/24_remotesyncers_scope_remotetarget_test.go
+++ b/test/e2e/syngit/24_remotesyncers_scope_remotetarget_test.go
@@ -18,6 +18,7 @@ package e2e_syngit
 
 import (
 	"context"
+	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -41,7 +42,7 @@ var _ = Describe("24 One RemoteTarget scoped by multiple RemoteSyncers", func() 
 	)
 
 	It("should deny the RemoteTarget creation", func() {
-		repoUrl := "https://" + gitP1Fqdn + "/syngituser/blue.git"
+		repoUrl := fmt.Sprintf("https://%s/%s/%s.git", gitP1Fqdn, giteaBaseNs, repo1)
 
 		By("creating the RemoteUser for Luffy")
 		luffySecretName := string(Luffy) + "-creds"
@@ -166,8 +167,8 @@ var _ = Describe("24 One RemoteTarget scoped by multiple RemoteSyncers", func() 
 		Wait3()
 		repo := &Repo{
 			Fqdn:   gitP1Fqdn,
-			Owner:  "syngituser",
-			Name:   "blue",
+			Owner:  giteaBaseNs,
+			Name:   repo1,
 			Branch: branch,
 		}
 		exists, err := IsObjectInRepo(*repo, cm)

--- a/test/e2e/syngit/26_remotetarget_hardreset_merge_test.go
+++ b/test/e2e/syngit/26_remotetarget_hardreset_merge_test.go
@@ -18,6 +18,7 @@ package e2e_syngit
 
 import (
 	"context"
+	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -56,7 +57,7 @@ var _ = Describe("26 Test hard-reset merge", func() {
 
 	It("should correctly pull the changes from the upstream", func() {
 
-		repoUrl := "https://" + gitP1Fqdn + "/syngituser/blue.git"
+		repoUrl := fmt.Sprintf("https://%s/%s/%s.git", gitP1Fqdn, giteaBaseNs, repo1)
 
 		By("creating the RemoteUser & RemoteUserBinding for Luffy")
 		luffySecretName := string(Luffy) + "-creds"
@@ -191,8 +192,8 @@ var _ = Describe("26 Test hard-reset merge", func() {
 		Wait3()
 		customBranchRepo := &Repo{
 			Fqdn:   gitP1Fqdn,
-			Owner:  "syngituser",
-			Name:   "blue",
+			Owner:  giteaBaseNs,
+			Name:   repo1,
 			Branch: customBranch,
 		}
 		exists, err := IsObjectInRepo(*customBranchRepo, cm)
@@ -329,8 +330,8 @@ var _ = Describe("26 Test hard-reset merge", func() {
 		Wait3()
 		upstreamRepo := &Repo{
 			Fqdn:   gitP1Fqdn,
-			Owner:  "syngituser",
-			Name:   "blue",
+			Owner:  giteaBaseNs,
+			Name:   repo1,
 			Branch: upstreamBranch,
 		}
 		exists, err = IsObjectInRepo(*upstreamRepo, cm2)
@@ -409,7 +410,7 @@ var _ = Describe("26 Test hard-reset merge", func() {
 
 	It("should overwrite the custom branch's commit by the upstream's branch one", func() { //nolint:dupl
 
-		repoUrl := "https://" + gitP1Fqdn + "/syngituser/blue.git"
+		repoUrl := fmt.Sprintf("https://%s/%s/%s.git", gitP1Fqdn, giteaBaseNs, repo1)
 
 		By("creating the RemoteUser & RemoteUserBinding for Luffy")
 		luffySecretName := string(Luffy) + "-creds"
@@ -544,8 +545,8 @@ var _ = Describe("26 Test hard-reset merge", func() {
 		Wait3()
 		customBranchRepo := &Repo{
 			Fqdn:   gitP1Fqdn,
-			Owner:  "syngituser",
-			Name:   "blue",
+			Owner:  giteaBaseNs,
+			Name:   repo1,
 			Branch: customBranch,
 		}
 		exists, err := IsObjectInRepo(*customBranchRepo, cm1)
@@ -682,8 +683,8 @@ var _ = Describe("26 Test hard-reset merge", func() {
 		Wait3()
 		upstreamRepo := &Repo{
 			Fqdn:   gitP1Fqdn,
-			Owner:  "syngituser",
-			Name:   "blue",
+			Owner:  giteaBaseNs,
+			Name:   repo1,
 			Branch: upstreamBranch,
 		}
 		exists, err = IsObjectInRepo(*upstreamRepo, cm2)

--- a/test/e2e/syngit/27_remotetarget_fastforward_hardreset_merge_test.go
+++ b/test/e2e/syngit/27_remotetarget_fastforward_hardreset_merge_test.go
@@ -18,6 +18,7 @@ package e2e_syngit
 
 import (
 	"context"
+	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -49,7 +50,7 @@ var _ = Describe("27 Test fast-forward or hard-reset merge", func() {
 
 	It("should try fast-forward and use hard-reset", func() { //nolint:dupl
 
-		repoUrl := "https://" + gitP1Fqdn + "/syngituser/blue.git"
+		repoUrl := fmt.Sprintf("https://%s/%s/%s.git", gitP1Fqdn, giteaBaseNs, repo1)
 
 		By("creating the RemoteUser & RemoteUserBinding for Luffy")
 		luffySecretName := string(Luffy) + "-creds"
@@ -184,8 +185,8 @@ var _ = Describe("27 Test fast-forward or hard-reset merge", func() {
 		Wait3()
 		customBranchRepo := &Repo{
 			Fqdn:   gitP1Fqdn,
-			Owner:  "syngituser",
-			Name:   "blue",
+			Owner:  giteaBaseNs,
+			Name:   repo1,
 			Branch: customBranch,
 		}
 		exists, err := IsObjectInRepo(*customBranchRepo, cm1)
@@ -322,8 +323,8 @@ var _ = Describe("27 Test fast-forward or hard-reset merge", func() {
 		Wait3()
 		upstreamRepo := &Repo{
 			Fqdn:   gitP1Fqdn,
-			Owner:  "syngituser",
-			Name:   "blue",
+			Owner:  giteaBaseNs,
+			Name:   repo1,
 			Branch: upstreamBranch,
 		}
 		exists, err = IsObjectInRepo(*upstreamRepo, cm2)

--- a/test/e2e/syngit/28_remoteuser_created_after_test.go
+++ b/test/e2e/syngit/28_remoteuser_created_after_test.go
@@ -18,6 +18,7 @@ package e2e_syngit
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -45,7 +46,7 @@ var _ = Describe("28 RemoteUser created after RemoteSyncer & RemoteTargets", fun
 
 	It("should associate the managed RemoteTargets to the new RemoteUser", func() {
 
-		repoUrl := "https://" + gitP1Fqdn + "/syngituser/blue.git"
+		repoUrl := fmt.Sprintf("https://%s/%s/%s.git", gitP1Fqdn, giteaBaseNs, repo1)
 		branches := strings.Join([]string{branch1, branch2}, ", ")
 		By("creating the RemoteSyncer")
 		remotesyncer := &syngit.RemoteSyncer{
@@ -129,8 +130,8 @@ var _ = Describe("28 RemoteUser created after RemoteSyncer & RemoteTargets", fun
 		Wait3()
 		repo := &Repo{
 			Fqdn:   gitP1Fqdn,
-			Owner:  "syngituser",
-			Name:   "blue",
+			Owner:  giteaBaseNs,
+			Name:   repo1,
 			Branch: branch1,
 		}
 		exists, err := IsObjectInRepo(*repo, cm)
@@ -139,8 +140,8 @@ var _ = Describe("28 RemoteUser created after RemoteSyncer & RemoteTargets", fun
 		Wait3()
 		repo = &Repo{
 			Fqdn:   gitP1Fqdn,
-			Owner:  "syngituser",
-			Name:   "blue",
+			Owner:  giteaBaseNs,
+			Name:   repo1,
 			Branch: branch2,
 		}
 		exists, err = IsObjectInRepo(*repo, cm)
@@ -149,8 +150,8 @@ var _ = Describe("28 RemoteUser created after RemoteSyncer & RemoteTargets", fun
 		Wait3()
 		repo = &Repo{
 			Fqdn:   gitP1Fqdn,
-			Owner:  "syngituser",
-			Name:   "blue",
+			Owner:  giteaBaseNs,
+			Name:   repo1,
 			Branch: string(Luffy),
 		}
 		exists, err = IsObjectInRepo(*repo, cm)

--- a/test/e2e/syngit/29_pattern_remove_test.go
+++ b/test/e2e/syngit/29_pattern_remove_test.go
@@ -18,11 +18,13 @@ package e2e_syngit
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	syngit "github.com/syngit-org/syngit/pkg/api/v1beta3"
+	"github.com/syngit-org/syngit/pkg/utils"
 	. "github.com/syngit-org/syngit/test/utils"
 	admissionv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -71,7 +73,7 @@ var _ = Describe("29 Add & remove patterns tests", func() {
 			return err == nil
 		}, timeout, interval).Should(BeTrue())
 
-		repoUrl := "https://" + gitP1Fqdn + "/syngituser/blue.git"
+		repoUrl := fmt.Sprintf("https://%s/%s/%s.git", gitP1Fqdn, giteaBaseNs, repo1)
 		branches := strings.Join([]string{branch1, branch2}, ", ")
 		By("creating the RemoteSyncer that target everybranches")
 		remotesyncer := &syngit.RemoteSyncer{
@@ -132,8 +134,8 @@ var _ = Describe("29 Add & remove patterns tests", func() {
 		Wait3()
 		repo := &Repo{
 			Fqdn:   gitP1Fqdn,
-			Owner:  "syngituser",
-			Name:   "blue",
+			Owner:  giteaBaseNs,
+			Name:   repo1,
 			Branch: branch1,
 		}
 		exists, err := IsObjectInRepo(*repo, cm1)
@@ -142,8 +144,8 @@ var _ = Describe("29 Add & remove patterns tests", func() {
 		Wait3()
 		repo = &Repo{
 			Fqdn:   gitP1Fqdn,
-			Owner:  "syngituser",
-			Name:   "blue",
+			Owner:  giteaBaseNs,
+			Name:   repo1,
 			Branch: branch2,
 		}
 		exists, err = IsObjectInRepo(*repo, cm1)
@@ -152,8 +154,8 @@ var _ = Describe("29 Add & remove patterns tests", func() {
 		Wait3()
 		repo = &Repo{
 			Fqdn:   gitP1Fqdn,
-			Owner:  "syngituser",
-			Name:   "blue",
+			Owner:  giteaBaseNs,
+			Name:   repo1,
 			Branch: string(Luffy),
 		}
 		exists, err = IsObjectInRepo(*repo, cm1)
@@ -189,8 +191,8 @@ var _ = Describe("29 Add & remove patterns tests", func() {
 		Wait3()
 		repo = &Repo{
 			Fqdn:   gitP1Fqdn,
-			Owner:  "syngituser",
-			Name:   "blue",
+			Owner:  giteaBaseNs,
+			Name:   repo1,
 			Branch: branch1,
 		}
 		exists, err = IsObjectInRepo(*repo, cm2)
@@ -199,8 +201,8 @@ var _ = Describe("29 Add & remove patterns tests", func() {
 		Wait3()
 		repo = &Repo{
 			Fqdn:   gitP1Fqdn,
-			Owner:  "syngituser",
-			Name:   "blue",
+			Owner:  giteaBaseNs,
+			Name:   repo1,
 			Branch: branch2,
 		}
 		exists, err = IsObjectInRepo(*repo, cm2)
@@ -209,8 +211,8 @@ var _ = Describe("29 Add & remove patterns tests", func() {
 		Wait3()
 		repo = &Repo{
 			Fqdn:   gitP1Fqdn,
-			Owner:  "syngituser",
-			Name:   "blue",
+			Owner:  giteaBaseNs,
+			Name:   repo1,
 			Branch: string(Luffy),
 		}
 		exists, err = IsObjectInRepo(*repo, cm2)
@@ -239,15 +241,15 @@ var _ = Describe("29 Add & remove patterns tests", func() {
 				cm3,
 				metav1.CreateOptions{},
 			)
-			return err != nil && strings.Contains(err.Error(), rtNotFound)
+			return err != nil && utils.ErrorTypeChecker(&utils.RemoteTargetNotFoundError{}, err.Error())
 		}, timeout, interval).Should(BeTrue())
 
 		By("checking that the configmap is not present on any branch")
 		Wait3()
 		repo = &Repo{
 			Fqdn:   gitP1Fqdn,
-			Owner:  "syngituser",
-			Name:   "blue",
+			Owner:  giteaBaseNs,
+			Name:   repo1,
 			Branch: branch1,
 		}
 		exists, err = IsObjectInRepo(*repo, cm3)
@@ -256,8 +258,8 @@ var _ = Describe("29 Add & remove patterns tests", func() {
 		Wait3()
 		repo = &Repo{
 			Fqdn:   gitP1Fqdn,
-			Owner:  "syngituser",
-			Name:   "blue",
+			Owner:  giteaBaseNs,
+			Name:   repo1,
 			Branch: branch2,
 		}
 		exists, err = IsObjectInRepo(*repo, cm3)
@@ -266,8 +268,8 @@ var _ = Describe("29 Add & remove patterns tests", func() {
 		Wait3()
 		repo = &Repo{
 			Fqdn:   gitP1Fqdn,
-			Owner:  "syngituser",
-			Name:   "blue",
+			Owner:  giteaBaseNs,
+			Name:   repo1,
 			Branch: string(Luffy),
 		}
 		exists, err = IsObjectInRepo(*repo, cm3)
@@ -301,7 +303,7 @@ var _ = Describe("29 Add & remove patterns tests", func() {
 			return err == nil
 		}, timeout, interval).Should(BeTrue())
 
-		repoUrl := "https://" + gitP1Fqdn + "/syngituser/blue.git"
+		repoUrl := fmt.Sprintf("https://%s/%s/%s.git", gitP1Fqdn, giteaBaseNs, repo1)
 		By("creating the RemoteSyncer that target everybranches")
 		remotesyncer := &syngit.RemoteSyncer{
 			ObjectMeta: metav1.ObjectMeta{
@@ -360,8 +362,8 @@ var _ = Describe("29 Add & remove patterns tests", func() {
 		Wait3()
 		repo := &Repo{
 			Fqdn:   gitP1Fqdn,
-			Owner:  "syngituser",
-			Name:   "blue",
+			Owner:  giteaBaseNs,
+			Name:   repo1,
 			Branch: string(Luffy),
 		}
 		exists, err := IsObjectInRepo(*repo, cm1)
@@ -390,15 +392,15 @@ var _ = Describe("29 Add & remove patterns tests", func() {
 				cm2,
 				metav1.CreateOptions{},
 			)
-			return err != nil && strings.Contains(err.Error(), ruNotFound)
+			return err != nil && utils.ErrorTypeChecker(&utils.RemoteUserSearchError{}, err.Error())
 		}, timeout, interval).Should(BeTrue())
 
 		By("checking that the configmap is not present on the user specific branch")
 		Wait3()
 		repo = &Repo{
 			Fqdn:   gitP1Fqdn,
-			Owner:  "syngituser",
-			Name:   "blue",
+			Owner:  giteaBaseNs,
+			Name:   repo1,
 			Branch: string(Luffy),
 		}
 		exists, err = IsObjectInRepo(*repo, cm2)

--- a/test/utils/.env
+++ b/test/utils/.env
@@ -14,7 +14,7 @@ BROOK_USERNAME="brook-jbg-sb"
 
 PLATFORM1="jupyter"
 PLATFORM2="saturn"
-REPO1="blue"
-REPO2="green"
+REPO1="merry"
+REPO2="sunny"
 
 GITEA_TEMP_CERT_DIR="/tmp/gitea-certs"

--- a/test/utils/gitea/delete-gitea-repos.sh
+++ b/test/utils/gitea/delete-gitea-repos.sh
@@ -33,9 +33,9 @@ fi
 GIT_TOKEN=$(echo "$TOKEN_RESPONSE" | sed -E 's/.*Access token was successfully created: ([a-f0-9]{40}).*/\1/')
 
 #
-# Delete the blue repo
+# Delete the repo1
 #
-DELETE_REPO_ENDPOINT="$GITEA_URL/api/v1/repos/$ADMIN_USERNAME/blue"
+DELETE_REPO_ENDPOINT="$GITEA_URL/api/v1/repos/$ADMIN_USERNAME/$REPO1"
 
 # Make the API call to create the repository
 response=$(curl -s -o /dev/null -w "%{http_code}" -X DELETE -k \
@@ -49,9 +49,9 @@ if [ "$response" != 204 ]; then
 fi
 
 #
-# Delete the green repo
+# Delete the repo2
 #
-DELETE_REPO_ENDPOINT="$GITEA_URL/api/v1/repos/$ADMIN_USERNAME/green"
+DELETE_REPO_ENDPOINT="$GITEA_URL/api/v1/repos/$ADMIN_USERNAME/$REPO2"
 
 # Make the API call to create the repository
 response=$(curl -s -o /dev/null -w "%{http_code}" -X DELETE -k \

--- a/test/utils/gitea/setup-gitea-bind-platform1.sh
+++ b/test/utils/gitea/setup-gitea-bind-platform1.sh
@@ -24,9 +24,9 @@ ADMIN_TOKEN=$(echo "$TOKEN_RESPONSE" | sed -E 's/.*Access token was successfully
 #
 ## CHOPPER
 #
-ADDED=$(add-collaborator $GITEA_URL $ADMIN_TOKEN "blue" $CHOPPER_USERNAME)
+ADDED=$(add-collaborator $GITEA_URL $ADMIN_TOKEN "$REPO1" $CHOPPER_USERNAME)
 if [ "$ADDED" = "1" ]; then
-  echo "User '$CHOPPER_USERNAME' failed to be added to repository 'blue' with 'write' access on $PLATFORM1."
+  echo "User '$CHOPPER_USERNAME' failed to be added to repository '$REPO1' with 'write' access on $PLATFORM1."
   exit 1
 fi
 
@@ -35,15 +35,15 @@ fi
 #
 ## LUFFY
 #
-ADDED=$(add-collaborator $GITEA_URL $ADMIN_TOKEN "blue" $LUFFY_USERNAME)
+ADDED=$(add-collaborator $GITEA_URL $ADMIN_TOKEN "$REPO1" $LUFFY_USERNAME)
 if [ "$ADDED" = "1" ]; then
-  echo "User '$LUFFY_USERNAME' failed to be added to repository 'blue' with 'write' access on $PLATFORM1."
+  echo "User '$LUFFY_USERNAME' failed to be added to repository '$REPO1' with 'write' access on $PLATFORM1."
   exit 1
 fi
 
-ADDED=$(add-collaborator $GITEA_URL $ADMIN_TOKEN "green" $LUFFY_USERNAME)
+ADDED=$(add-collaborator $GITEA_URL $ADMIN_TOKEN "$REPO2" $LUFFY_USERNAME)
 if [ "$ADDED" = "1" ]; then
-  echo "User '$LUFFY_USERNAME' failed to be added to repository 'green' with 'write' access on $PLATFORM1."
+  echo "User '$LUFFY_USERNAME' failed to be added to repository '$REPO2' with 'write' access on $PLATFORM1."
   exit 1
 fi
 
@@ -52,14 +52,14 @@ fi
 #
 ## BROOK
 #
-ADDED=$(add-collaborator $GITEA_URL $ADMIN_TOKEN "blue" $BROOK_USERNAME)
+ADDED=$(add-collaborator $GITEA_URL $ADMIN_TOKEN "$REPO1" $BROOK_USERNAME)
 if [ "$ADDED" = "1" ]; then
-  echo "User '$BROOK_USERNAME' failed to be added to repository 'blue' with 'write' access on $PLATFORM1."
+  echo "User '$BROOK_USERNAME' failed to be added to repository '$REPO1' with 'write' access on $PLATFORM1."
   exit 1
 fi
 
-ADDED=$(add-collaborator $GITEA_URL $ADMIN_TOKEN "green" $BROOK_USERNAME)
+ADDED=$(add-collaborator $GITEA_URL $ADMIN_TOKEN "$REPO2" $BROOK_USERNAME)
 if [ "$ADDED" = "1" ]; then
-  echo "User '$BROOK_USERNAME' failed to be added to repository 'green' with 'write' access on $PLATFORM1."
+  echo "User '$BROOK_USERNAME' failed to be added to repository '$REPO2' with 'write' access on $PLATFORM1."
   exit 1
 fi

--- a/test/utils/gitea/setup-gitea-bind-platform2.sh
+++ b/test/utils/gitea/setup-gitea-bind-platform2.sh
@@ -25,17 +25,17 @@ ADMIN_TOKEN=$(echo "$TOKEN_RESPONSE" | sed -E 's/.*Access token was successfully
 #
 ## LUFFY
 #
-ADDED=$(add-collaborator $GITEA_URL $ADMIN_TOKEN "blue" $LUFFY_USERNAME)
+ADDED=$(add-collaborator $GITEA_URL $ADMIN_TOKEN "$REPO1" $LUFFY_USERNAME)
 if [ "$ADDED" = "1" ]; then
-  echo "User '$LUFFY_USERNAME' failed to be added to repository 'blue' with 'write' access on $PLATFORM2."
+  echo "User '$LUFFY_USERNAME' failed to be added to repository '$REPO1' with 'write' access on $PLATFORM2."
   exit 1
 fi
 
 #
 ## BROOK
 #
-ADDED=$(add-collaborator $GITEA_URL $ADMIN_TOKEN "blue" $BROOK_USERNAME)
+ADDED=$(add-collaborator $GITEA_URL $ADMIN_TOKEN "$REPO1" $BROOK_USERNAME)
 if [ "$ADDED" = "1" ]; then
-  echo "User '$BROOK_USERNAME' failed to be added to repository 'blue' with 'write' access on $PLATFORM2."
+  echo "User '$BROOK_USERNAME' failed to be added to repository '$REPO1' with 'write' access on $PLATFORM2."
   exit 1
 fi

--- a/test/utils/gitea/setup-gitea-repos.sh
+++ b/test/utils/gitea/setup-gitea-repos.sh
@@ -33,13 +33,13 @@ fi
 GIT_TOKEN=$(echo "$TOKEN_RESPONSE" | sed -E 's/.*Access token was successfully created: ([a-f0-9]{40}).*/\1/')
 
 #
-# Create the blue repo
+# Create the repo1
 #
 CREATE_REPO_ENDPOINT="$GITEA_URL/api/v1/user/repos"
 
 JSON_PAYLOAD=$(cat <<EOF
 {
-  "name": "blue",
+  "name": "$REPO1",
   "private": false,
   "auto_init": true,
   "description": "A new sample repository"
@@ -61,13 +61,13 @@ fi
 
 
 #
-# Create the green repo
+# Create the repo2
 #
 CREATE_REPO_ENDPOINT="$GITEA_URL/api/v1/user/repos"
 
 JSON_PAYLOAD=$(cat <<EOF
 {
-  "name": "green",
+  "name": "$REPO2",
   "private": false,
   "auto_init": true,
   "description": "A new sample repository"

--- a/test/utils/gitea/setup-gitea-users.sh
+++ b/test/utils/gitea/setup-gitea-users.sh
@@ -29,7 +29,7 @@ kubectl exec -i $POD_NAME -n $NS_SATURN -- gitea admin user change-password \
 
 
 # chopper-jb
-# Have access only to the blue repo on the jupyter gitea
+# Have access only to the repo1 on the jupyter gitea
 CHOPPER_PWD="chopper-jb-pwd"
 
 POD_NAME=$(kubectl get pods -n $NS_JUPYTER -l app.kubernetes.io/name=gitea -o jsonpath="{.items[0].metadata.name}")
@@ -44,8 +44,8 @@ kubectl exec -i $POD_NAME -n $NS_JUPYTER -- gitea admin user change-password \
 
 
 # luffy-jbg-sb
-# Have access to the blue and green repo on the jupyter gitea
-# Have access to the blue repo on the saturn gitea
+# Have access to the repo1 and repo2 on the jupyter gitea
+# Have access to the repo1 on the saturn gitea
 LUFFY_PWD="luffy-jbg-sb-pwd"
 
 POD_NAME=$(kubectl get pods -n $NS_JUPYTER -l app.kubernetes.io/name=gitea -o jsonpath="{.items[0].metadata.name}")
@@ -72,8 +72,8 @@ kubectl exec -i $POD_NAME -n $NS_SATURN -- gitea admin user change-password \
 
 
 # brook-jbg-sb
-# Have access to the blue and green repo on the jupyter gitea
-# Have access to the blue repo on the saturn gitea
+# Have access to the repo1 and repo2 on the jupyter gitea
+# Have access to the repo1 on the saturn gitea
 BROOK_PWD="brook-jbg-sb-pwd"
 
 POD_NAME=$(kubectl get pods -n $NS_JUPYTER -l app.kubernetes.io/name=gitea -o jsonpath="{.items[0].metadata.name}")

--- a/test/utils/mock-users.go
+++ b/test/utils/mock-users.go
@@ -20,8 +20,7 @@ var (
 	Brook   TestUser
 )
 
-var FullPermissionsUsers []TestUser
-var Users []TestUser
+var Users map[string]TestUser
 
 type SyngitTestUsersClientset struct {
 	admin  *Clientset
@@ -60,14 +59,23 @@ func (tu *SyngitTestUsersClientset) As(username TestUser) CustomClient {
 }
 
 func (tu *SyngitTestUsersClientset) Initialize(cfg *rest.Config) error {
+	// Platform engineer : admin in the whole cluster
 	Admin = TestUser(os.Getenv("ADMIN_USERNAME"))
-	Sanji = TestUser(os.Getenv("SANJI_USERNAME"))
-	Chopper = TestUser(os.Getenv("CHOPPER_USERNAME"))
+	// DevOps: admin in the test namespace
 	Luffy = TestUser(os.Getenv("LUFFY_USERNAME"))
+	// DevOps: admin in the test namespace
+	Chopper = TestUser(os.Getenv("CHOPPER_USERNAME"))
+	// DevOps : admin in the test namespace
+	Sanji = TestUser(os.Getenv("SANJI_USERNAME"))
+	// Limited DevOps : CRUD only on syngit objects that belongs to him
+	//   Can get secrets (to authenticate with the RemoteUser)
 	Brook = TestUser(os.Getenv("BROOK_USERNAME"))
 
-	FullPermissionsUsers = []TestUser{Sanji, Chopper, Luffy}
-	Users = append(FullPermissionsUsers, Brook)
+	Users = map[string]TestUser{}
+	Users[os.Getenv("LUFFY_USERNAME")] = Luffy
+	Users[os.Getenv("CHOPPER_USERNAME")] = Chopper
+	Users[os.Getenv("SANJI_USERNAME")] = Sanji
+	Users[os.Getenv("BROOK_USERNAME")] = Brook
 
 	tu.config = cfg
 

--- a/test/utils/syngit.go
+++ b/test/utils/syngit.go
@@ -92,11 +92,6 @@ func GetLatestCommit(repoUrl string, repoOwner string, repoName string) (*Commit
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if err != nil {
 		return nil, fmt.Errorf("failed to get latest commit: %v", err)
 	}
 	defer resp.Body.Close()


### PR DESCRIPTION
This PR brings 2 improvements:

#### RBAC test refactor

Before, the test users were all used almost randomly in the tests. This PR brings clear distinct roles/personas for each users (described in the documentation). It is now easier to write tests using the right role/persona.

#### Convert dynamic webhook's errors into type

Errors used during the interception process are now all referenced as a type that implement the `ResourceInterceptorError` interface.