### PR TITLE
:bug: Fix pattern applies before RUB creation

### DIFF
--- a/internal/patterns/v1beta3/remoteuser_searchremotetarget.go
+++ b/internal/patterns/v1beta3/remoteuser_searchremotetarget.go
@@ -51,7 +51,7 @@ func (rusp *RemoteUserSearchRemoteTargetPattern) Diff(ctx context.Context) *Erro
 		}),
 	}
 	remoteUserBindingList := &syngit.RemoteUserBindingList{}
-	listErr := rusp.Client.List(ctx, remoteUserBindingList, rubListOps)
+	listErr := getAssociatedRemoteUserBinding(ctx, rusp.Client, remoteUserBindingList, rubListOps, 5)
 	if listErr != nil {
 		return &ErrorPattern{Message: listErr.Error(), Reason: Errored}
 	}
@@ -60,7 +60,7 @@ func (rusp *RemoteUserSearchRemoteTargetPattern) Diff(ctx context.Context) *Erro
 		return &ErrorPattern{Message: fmt.Sprintf("only one RemoteUserBinding for the user %s should be managed by Syngit", rusp.Username), Reason: Denied}
 	}
 	if len(remoteUserBindingList.Items) == 0 {
-		return nil
+		return &ErrorPattern{Message: fmt.Sprintf("a RemoteUserBinding managed by Syngit should exists for the user %s", rusp.Username), Reason: Errored}
 	}
 	rusp.RemoteUserBinding = &remoteUserBindingList.Items[0]
 

--- a/internal/patterns/v1beta3/utils.go
+++ b/internal/patterns/v1beta3/utils.go
@@ -132,3 +132,15 @@ func slicesDifference(slice1 []string, slice2 []string) []string {
 
 	return diff
 }
+
+func getAssociatedRemoteUserBinding(ctx context.Context, k8sClient controllerClient.Client, remoteUserBindingList *syngit.RemoteUserBindingList, listOpts *client.ListOptions, retryNumber int) error {
+	listErr := k8sClient.List(ctx, remoteUserBindingList, listOpts)
+	if listErr != nil {
+		return listErr
+	}
+
+	if len(remoteUserBindingList.Items) == 0 && retryNumber > 0 {
+		return getAssociatedRemoteUserBinding(ctx, k8sClient, remoteUserBindingList, listOpts, retryNumber-1)
+	}
+	return nil
+}


### PR DESCRIPTION
When applying a `RemoteUser` after the `RemoteSyncer`, if the remoteuserbinding association pattern is used, the corresponding `RemoteUserBinding` was created AFTER the execution of the remotetarget patterns. Therefore, none of the `RemoteTargets` could be associated to a `RemoteUserBinding` that does not exists at that time.

Thus, retry 5 times the get action to make sure that the associated `RemoteUserBinding` is created before executing the remotetargets patterns.