### PR TITLE
:bug: Fix empty commit bug

### DIFF
--- a/charts/0.4.1/templates/controller/manager.yaml
+++ b/charts/0.4.1/templates/controller/manager.yaml
@@ -62,10 +62,7 @@ spec:
         resources: {{ toYaml .Values.controller.resources | nindent 10 }}
         ports:
         - containerPort: 9443
-          name: wbhk-crd-srv
-          protocol: TCP
-        - containerPort: 9444
-          name: wbhk-pusher-srv
+          name: webhook-svc
           protocol: TCP
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs

--- a/charts/0.4.1/values.yaml
+++ b/charts/0.4.1/values.yaml
@@ -9,7 +9,7 @@ controller:
   image:
     prefix: ghcr.io/syngit-org
     name: syngit
-    tag: v0.4.0
+    tag: v0.4.1
     # imagePullSecrets:
     # imagePullPolicy:
 


### PR DESCRIPTION
A specific use-case where the user first push on the main branch and then push the same object to a different branch was throwing an error considering the commit as empty. It is considered as empty because syngit first fetch the changes from the upstream (containing the exact same object). In this specific case, no new commit is created and the changes from the upstream are simply pushed to the target.