### PR TITLE
:bug: Fix already deleted file block the deletion on the api side

### DIFF
--- a/internal/interceptor/git_pusher.go
+++ b/internal/interceptor/git_pusher.go
@@ -222,7 +222,7 @@ func (gp *GitPusher) commitChanges(w *git.Worktree, pathToAdd string, targetRepo
 
 	if gp.interceptedYAML == "" { // The file has been deleted
 		_, err := w.Remove(pathToAdd)
-		if err != nil {
+		if err != nil && !strings.Contains(err.Error(), "entry not found") {
 			errMsg := "failed to delete file in staging area: " + err.Error()
 			return "", errors.New(errMsg)
 		}


### PR DESCRIPTION
Before this fix, when trying to delete a scoped resource that is not present on the git repository, the deletion was blocked before reaching the api. Now, the process bypass the entry not found error to directly let pass the request to the api.