### PR TITLE
:bug: Fix remote user auto association with wrong username

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -43,6 +43,7 @@ body:
         - syngit version:
         - syngit image tag:
         - syngit controller's log:
+        - kubernetes distribution: Rancher v2.11, Openshift 4.18, k3s v1.30, k0s v1.31, ...
     validations:
       required: true
   - type: textarea

--- a/charts/0.4.5/templates/controller/manager.yaml
+++ b/charts/0.4.5/templates/controller/manager.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     control-plane: controller-manager
     app.kubernetes.io/name: deployment
+    app.kubernetes.io/version: {{ .Chart.Version }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: manager
     app.kubernetes.io/created-by: {{ .Release.Name }}
@@ -22,6 +23,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/version: {{ .Chart.Version }}
     spec:
       {{- if .Values.controller.image.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/0.4.5/templates/post-migration/post-migration-rbac.yaml
+++ b/charts/0.4.5/templates/post-migration/post-migration-rbac.yaml
@@ -1,0 +1,98 @@
+{{- if .Release.IsUpgrade -}}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: post-migration
+  labels:
+    app.kubernetes.io/name: job
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: post-migration
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: post-migration
+  labels:
+    app.kubernetes.io/name: job
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: helm-post-migration
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - "users"
+  - "groups"
+  verbs:
+  - "impersonate"
+- apiGroups:
+  - ""
+  - "syngit.io"
+  resources:
+  - "pods"
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "syngit.io"
+  resources:
+  - remoteusers
+  verbs:
+  - update
+  - patch
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "syngit.io"
+  resources:
+  - remotetargets
+  - remoteuserbindings
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: post-migration
+  labels:
+    app.kubernetes.io/name: job
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: helm-post-migration
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: post-migration
+subjects:
+  - kind: ServiceAccount
+    name: post-migration
+    namespace: {{ .Release.Namespace }}
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: syngit:post-migration-patch
+{{- end }}

--- a/charts/0.4.5/templates/post-migration/post-migration.yaml
+++ b/charts/0.4.5/templates/post-migration/post-migration.yaml
@@ -1,0 +1,102 @@
+{{- if .Release.IsUpgrade -}}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-post-migration
+  labels:
+    app.kubernetes.io/name: job
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: post-migration
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  template:
+    spec:
+      serviceAccountName: post-migration
+      automountServiceAccountToken: true
+      containers:
+        - name: post-migration
+          image: bitnami/kubectl:1.32.0
+          command:
+            - /bin/sh
+            - -c
+            - |
+              #!/bin/sh
+              set -e
+
+              kubectl wait --for=condition=ready pods -l app.kubernetes.io/instance={{ .Release.Name }} -l app.kubernetes.io/version={{ .Chart.Version }} \
+                -n {{ .Release.Namespace }} --timeout=500s
+
+              echo "Waiting for the leader to be elected..."
+              sleep 30
+
+              API_SERVER="https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}"
+              TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+              CACERT=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+
+              echo "Deleting RemoteTargets managed by syngit..."
+              kubectl delete remotetarget -l managed-by=syngit.io -A || true
+
+              echo "Fetching RemoteUserBindings managed by syngit.io..."
+              bindings=$(kubectl get remoteuserbindings -l managed-by=syngit.io -A -o json)
+
+              echo "$bindings" | jq -c '.items[]' | while read -r binding; do
+                bindingname=$(echo "$binding" | jq -r '.metadata.name')
+                username=$(echo "$binding" | jq -r '.spec.subject.name')
+                remoteusers=$(echo "$binding" | jq -c '.spec.remoteUserRefs[]')
+                namespace=$(echo "$binding" | jq -r '.metadata.namespace')
+
+                echo "Remote RemoteTarget references from the RemoteUserBinding..."
+                kubectl --token="$TOKEN" \
+                        --server="$API_SERVER" \
+                        --certificate-authority="$CACERT" \
+                        --as="$username" \
+                        --as-group="syngit:post-migration-patch" \
+                        -n "$namespace" \
+                        delete remoteuserbinding "$bindingname"
+
+                echo "Processing binding for user: $username"
+
+                echo "$remoteusers" | while read -r ref; do
+                  name=$(echo "$ref" | jq -r '.name')
+                  
+                  echo "Double-update RemoteUser $name in namespace $namespace as $username... 1"
+                  
+                  kubectl --token="$TOKEN" \
+                          --server="$API_SERVER" \
+                          --certificate-authority="$CACERT" \
+                          --as="$username" \
+                          --as-group="syngit:post-migration-patch" \
+                          -n "$namespace" \
+                          patch remoteuser "$name" --type='merge' -p '{
+                    "metadata": {
+                      "annotations": {
+                        "syngit.io/remoteuserbinding.managed": "false"
+                      }
+                    }
+                  }'
+                  
+                  echo "Double-update RemoteUser $name in namespace $namespace as $username... 2"
+
+                  kubectl --token="$TOKEN" \
+                          --server="$API_SERVER" \
+                          --certificate-authority="$CACERT" \
+                          --as="$username" \
+                          --as-group="syngit:post-migration-patch" \
+                          -n "$namespace" \
+                          patch remoteuser "$name" --type='merge' -p '{
+                    "metadata": {
+                      "annotations": {
+                        "syngit.io/remoteuserbinding.managed": "true"
+                      }
+                    }
+                  }'
+                done
+              done
+      restartPolicy: Never
+  backoffLimit: 4
+{{- end }}

--- a/internal/interceptor/webhook_request_checker.go
+++ b/internal/interceptor/webhook_request_checker.go
@@ -255,6 +255,7 @@ func (wrc *WebhookRequestChecker) setUserTarget(details *wrcDetails) (bool, erro
 	var gitUser *gitUser
 	remoteUserBinding, gitUser, rubErr := wrc.getRemoteUserBinding(incomingUser.Username, fqdn, details)
 	if rubErr != nil {
+		details.messageAddition = rubErr.Error()
 		return false, rubErr
 	}
 
@@ -274,6 +275,7 @@ func (wrc *WebhookRequestChecker) setUserTarget(details *wrcDetails) (bool, erro
 		}
 		err := patterns.Trigger(remoteTargetPattern, ctx)
 		if err != nil {
+			details.messageAddition = err.Error()
 			return false, err
 		}
 		if wrc.remoteSyncer.Annotations[syngit.RtAnnotationKeyUserSpecific] != "" {

--- a/internal/patterns/v1beta3/remoteuser_association.go
+++ b/internal/patterns/v1beta3/remoteuser_association.go
@@ -64,14 +64,15 @@ func (ruap *RemoteUserAssociationPattern) Diff(ctx context.Context) *ErrorPatter
 		return &ErrorPattern{Message: diffErr.Error(), Reason: Errored}
 	}
 
-	name := syngit.RubNamePrefix + "-" + ruap.Username
+	sanitizedUsername := SanitizeUsername(ruap.Username)
+	name := syngit.RubNamePrefix + "-" + sanitizedUsername
 
 	// List all the RemoteUserBindings that are associated to this user and managed by Syngit.
 	remoteUserBindingList := &syngit.RemoteUserBindingList{}
 	listOps := &client.ListOptions{
 		LabelSelector: labels.SelectorFromSet(labels.Set{
 			syngit.ManagedByLabelKey: syngit.ManagedByLabelValue,
-			syngit.K8sUserLabelKey:   ruap.Username,
+			syngit.K8sUserLabelKey:   sanitizedUsername,
 		}),
 		Namespace: ruap.NamespacedName.Namespace,
 	}
@@ -114,7 +115,7 @@ func (ruap *RemoteUserAssociationPattern) Diff(ctx context.Context) *ErrorPatter
 		// Set the labels
 		rub.Labels = map[string]string{
 			syngit.ManagedByLabelKey: syngit.ManagedByLabelValue,
-			syngit.K8sUserLabelKey:   ruap.Username,
+			syngit.K8sUserLabelKey:   sanitizedUsername,
 		}
 
 		subject := &rbacv1.Subject{

--- a/internal/patterns/v1beta3/remoteuser_searchremotetarget.go
+++ b/internal/patterns/v1beta3/remoteuser_searchremotetarget.go
@@ -47,7 +47,7 @@ func (rusp *RemoteUserSearchRemoteTargetPattern) Diff(ctx context.Context) *Erro
 		Namespace: rusp.NamespacedName.Namespace,
 		LabelSelector: labels.SelectorFromSet(labels.Set{
 			syngit.ManagedByLabelKey: syngit.ManagedByLabelValue,
-			syngit.K8sUserLabelKey:   rusp.Username,
+			syngit.K8sUserLabelKey:   SanitizeUsername(rusp.Username),
 		}),
 	}
 	remoteUserBindingList := &syngit.RemoteUserBindingList{}

--- a/internal/patterns/v1beta3/remoteuser_userspecific_pattern.go
+++ b/internal/patterns/v1beta3/remoteuser_userspecific_pattern.go
@@ -3,6 +3,7 @@ package v1beta3
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	syngit "github.com/syngit-org/syngit/pkg/api/v1beta3"
 	"github.com/syngit-org/syngit/pkg/utils"
@@ -30,18 +31,27 @@ func (usp *UserSpecificPattern) GetRemoteTarget() syngit.RemoteTarget {
 
 func (usp *UserSpecificPattern) Setup(ctx context.Context) *ErrorPattern {
 	if usp.remoteTargetToBeSetuped != nil {
+		alreadyExists := false
 		createErr := usp.Client.Create(ctx, usp.remoteTargetToBeSetuped)
 		if createErr != nil {
-			return &ErrorPattern{Message: createErr.Error(), Reason: Errored}
+			// If the associated RemoteUser does not exists anymore,
+			// we keep the RemoteTarget. It will be deleted when the
+			// RemoteSyncer will be deleted.
+			if !strings.Contains(createErr.Error(), "already exists") {
+				return &ErrorPattern{Message: createErr.Error(), Reason: Errored}
+			}
+			alreadyExists = true
 		}
 
-		spec := usp.RemoteUserBinding.Spec.DeepCopy()
-		spec.RemoteTargetRefs = append(spec.RemoteTargetRefs, corev1.ObjectReference{
-			Name: usp.remoteTargetToBeSetuped.Name,
-		})
-		updateErr := updateOrDeleteRemoteUserBinding(ctx, usp.Client, *spec, *usp.RemoteUserBinding, 2)
-		if updateErr != nil {
-			return &ErrorPattern{Message: updateErr.Error(), Reason: Errored}
+		if !alreadyExists {
+			spec := usp.RemoteUserBinding.Spec.DeepCopy()
+			spec.RemoteTargetRefs = append(spec.RemoteTargetRefs, corev1.ObjectReference{
+				Name: usp.remoteTargetToBeSetuped.Name,
+			})
+			updateErr := updateOrDeleteRemoteUserBinding(ctx, usp.Client, *spec, *usp.RemoteUserBinding, 2)
+			if updateErr != nil {
+				return &ErrorPattern{Message: updateErr.Error(), Reason: Errored}
+			}
 		}
 	}
 
@@ -96,7 +106,7 @@ func (usp *UserSpecificPattern) Diff(ctx context.Context) *ErrorPattern {
 	listOps := &client.ListOptions{
 		LabelSelector: labels.SelectorFromSet(labels.Set{
 			syngit.ManagedByLabelKey: syngit.ManagedByLabelValue,
-			syngit.K8sUserLabelKey:   usp.Username,
+			syngit.K8sUserLabelKey:   SanitizeUsername(usp.Username),
 		}),
 		Namespace: usp.RemoteSyncer.Namespace,
 	}
@@ -189,7 +199,7 @@ func (usp *UserSpecificPattern) getExistingRemoteTarget(ctx context.Context) ([]
 		LabelSelector: labels.SelectorFromSet(labels.Set{
 			syngit.ManagedByLabelKey: syngit.ManagedByLabelValue,
 			syngit.RtLabelKeyPattern: syngit.RtLabelValueOneUserOneBranch,
-			syngit.K8sUserLabelKey:   usp.Username,
+			syngit.K8sUserLabelKey:   SanitizeUsername(usp.Username),
 		}),
 		Namespace: usp.RemoteSyncer.Namespace,
 	}
@@ -219,7 +229,7 @@ func (usp *UserSpecificPattern) getExistingRemoteTarget(ctx context.Context) ([]
 
 func (usp *UserSpecificPattern) buildRemoteTarget(targetRepo string) (*syngit.RemoteTarget, error) {
 
-	rtName, nameErr := utils.RemoteTargetNameConstructor(usp.RemoteSyncer.Spec.RemoteRepository, usp.RemoteSyncer.Spec.DefaultBranch, targetRepo, usp.Username)
+	rtName, nameErr := utils.RemoteTargetNameConstructor(usp.RemoteSyncer.Spec.RemoteRepository, usp.RemoteSyncer.Spec.DefaultBranch, targetRepo, SanitizeUsername(usp.Username))
 	if nameErr != nil {
 		return nil, nameErr
 	}
@@ -231,14 +241,14 @@ func (usp *UserSpecificPattern) buildRemoteTarget(targetRepo string) (*syngit.Re
 			Labels: map[string]string{
 				syngit.ManagedByLabelKey: syngit.ManagedByLabelValue,
 				syngit.RtLabelKeyPattern: syngit.RtLabelValueOneUserOneBranch,
-				syngit.K8sUserLabelKey:   usp.Username,
+				syngit.K8sUserLabelKey:   SanitizeUsername(usp.Username),
 			},
 		},
 		Spec: syngit.RemoteTargetSpec{
 			UpstreamRepository: usp.RemoteSyncer.Spec.RemoteRepository,
 			UpstreamBranch:     usp.RemoteSyncer.Spec.DefaultBranch,
 			TargetRepository:   targetRepo,
-			TargetBranch:       usp.Username,
+			TargetBranch:       SoftSanitizeUsername(usp.Username),
 			MergeStrategy:      syngit.TryFastForwardOrHardReset,
 		},
 	}

--- a/internal/patterns/v1beta3/utils.go
+++ b/internal/patterns/v1beta3/utils.go
@@ -2,7 +2,10 @@ package v1beta3
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
@@ -13,6 +16,24 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	controllerClient "sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+func SanitizeUsername(username string) string {
+	h := sha256.Sum256([]byte(username))
+	return hex.EncodeToString(h[:])[:12]
+}
+
+func SoftSanitizeUsername(username string) string {
+	const validPattern = `^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
+	validRegex := regexp.MustCompile(validPattern)
+
+	if validRegex.MatchString(username) {
+		return username
+	}
+
+	allowedChars := regexp.MustCompile(`[^a-z0-9\.-]`)
+	sanitized := allowedChars.ReplaceAllString(strings.ToLower(username), "-")
+	return sanitized
+}
 
 func generateName(ctx context.Context, client controllerClient.Client, object controllerClient.Object, suffixNumber int) (string, error) {
 	oldName := object.GetName()

--- a/test/e2e/syngit/01_setup_remoteusers_test.go
+++ b/test/e2e/syngit/01_setup_remoteusers_test.go
@@ -68,7 +68,7 @@ var _ = Describe("01 Create RemoteUser", func() {
 		By("checking if the RemoteUserBinding for Luffy exists")
 		Wait3()
 		nnRubLuffy := types.NamespacedName{
-			Name:      fmt.Sprintf("%s-%s", syngit.RubNamePrefix, string(Luffy)),
+			Name:      fmt.Sprintf("%s-%s", syngit.RubNamePrefix, SanitizeUsername(string(Luffy))),
 			Namespace: namespace,
 		}
 		rubLuffy := &syngit.RemoteUserBinding{}

--- a/test/e2e/syngit/06_objects_lifecycle_test.go
+++ b/test/e2e/syngit/06_objects_lifecycle_test.go
@@ -112,7 +112,7 @@ var _ = Describe("06 Test objects lifecycle", func() {
 		By("checking that the RemoteUserBinding refers to 2 RemoteUsers")
 		Wait3()
 		nnRub := types.NamespacedName{
-			Name:      fmt.Sprintf("%s-%s", syngit.RubNamePrefix, string(Luffy)),
+			Name:      fmt.Sprintf("%s-%s", syngit.RubNamePrefix, SanitizeUsername(string(Luffy))),
 			Namespace: namespace,
 		}
 		getRub := &syngit.RemoteUserBinding{}

--- a/test/e2e/syngit/12_remoteuserbinding_managed_test.go
+++ b/test/e2e/syngit/12_remoteuserbinding_managed_test.go
@@ -57,7 +57,7 @@ var _ = Describe("12 RemoteUserBinding managed by checker", func() {
 		}, timeout, interval).Should(BeTrue())
 
 		By("creating the RemoteUserBinding with the exact same name as the generated one")
-		remoteUserBindingLuffyName := syngit.RubNamePrefix + "-" + string(Luffy)
+		remoteUserBindingLuffyName := syngit.RubNamePrefix + "-" + SanitizeUsername(string(Luffy))
 		remoteUserBindingLuffy := &syngit.RemoteUserBinding{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      remoteUserBindingLuffyName,
@@ -77,7 +77,7 @@ var _ = Describe("12 RemoteUserBinding managed by checker", func() {
 		}, timeout, interval).Should(BeTrue())
 
 		By("creating the RemoteUserBinding with the exact same name as the generated one & the suffix 1")
-		remoteUserBindingLuffyName1 := fmt.Sprintf("%s-%s-1", syngit.RubNamePrefix, string(Luffy))
+		remoteUserBindingLuffyName1 := fmt.Sprintf("%s-%s-1", syngit.RubNamePrefix, SanitizeUsername(string(Luffy)))
 		remoteUserBindingLuffy1 := &syngit.RemoteUserBinding{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      remoteUserBindingLuffyName1,
@@ -121,7 +121,7 @@ var _ = Describe("12 RemoteUserBinding managed by checker", func() {
 
 		By("checking if the RemoteUserBinding with suffix 2 exists")
 		Wait3()
-		remoteUserBindingName := fmt.Sprintf("%s-%s-2", syngit.RubNamePrefix, string(Luffy))
+		remoteUserBindingName := fmt.Sprintf("%s-%s-2", syngit.RubNamePrefix, SanitizeUsername(string(Luffy)))
 		nnRubLuffy := types.NamespacedName{
 			Name:      remoteUserBindingName,
 			Namespace: namespace,

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2" //nolint:golint,revive
+	syngit_utils "github.com/syngit-org/syngit/internal/patterns/v1beta3"
 )
 
 const (
@@ -172,4 +173,8 @@ func GetProjectDir() (string, error) {
 	}
 	wd = strings.Split(wd, "/test/e2e")[0]
 	return wd, nil
+}
+
+func SanitizeUsername(username string) string {
+	return syngit_utils.SanitizeUsername(username)
 }


### PR DESCRIPTION
Some usernames in Kubernetes contains characters that are not permitted to use in the resources name or as a value of label. For example `system:admin` contains "`:`".

This PR brings a new way to manage the pattern associations. Instead of directly use the raw username in the name of the `RemoteUserBinding` and `RemoteTarget` resources, we hash it using SHA256. We use this hash in the label as well. This way, each resources are unique (one per username) and can be scoped by the different patterns logic.

We use the `SanitizeUsername(username)` from the `utils` package to convert the username into its SHA256 corresponding hash. We use the `SoftSanitizeUsername(username)` to convert every problematic characters (those which does not respect the regex for a k8s resource name) into a simple "`-`". It used to generate the custom branch name for the user.