### PR TITLE
:sparkles: feat(helm) Add cert-manager as a dependency of syngit Helm chart

### DIFF
--- a/.github/workflows/helm-chart-releaser.yml
+++ b/.github/workflows/helm-chart-releaser.yml
@@ -28,6 +28,19 @@ jobs:
         uses: azure/setup-helm@b7246b12e77f7134dc2d460a3d5bad15bbe29390 #v4.1.0
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Build chart dependencies
+        run: |
+          for chart in charts/*; do
+            if [ -f "$chart/Chart.yaml" ]; then
+              helm dependency update "$chart"
+            fi
+          done
+
+      - name: Add Helm repositories
+        run: |
+          helm repo add jetstack https://charts.jetstack.io
+          helm repo update
           
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@a917fd15b20e8b64b94d9158ad54cd6345335584 #v1.6.0

--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ go.work
 # Kubernetes Generated files - skip generated files, except for vendored files
 !vendor/**/zz_generated.*
 
-# editor and IDE paraphernalia
+# Editor and IDE paraphernalia
 .idea
 .vscode
 *.swp
@@ -34,6 +34,10 @@ config/local/deploy/webhook/webhook.yaml
 config/local/run/crd
 config/local/run/webhook/webhook.yaml
 
-# developer's specific tests
+# Developer's specific tests
 config/samples/test
 test/e2e/syngit/*.ignore
+
+# Charts dependencies
+charts/*/charts
+charts/*/*.lock

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Syngit is a Kubernetes operator that allows you to push resources on a git repos
 
 ### Prerequisites
 - Access to a Kubernetes v1.11.3+ cluster.
-- ⚠️ Cert Manager version 1.13+ on the cluster.
+- ⚠️ Cert Manager version ~1.17.x installed on the cluster.
 - Helm version v3.0.0+.
 
 ### Installation

--- a/charts/0.4.8/Chart.yaml
+++ b/charts/0.4.8/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+name: syngit
+description: An operator to push resources to git
+type: application
+version: 0.4.8
+appVersion: 0.4.8
+home: https://github.com/syngit-org/syngit
+icon: https://raw.githubusercontent.com/syngit-org/syngit/main/img/mini-icon.png
+dependencies:
+  - name: cert-manager
+    condition: certmanager.dependency.enabled
+    repository: https://charts.jetstack.io
+    version: ~v1.17
+maintainers:
+  - email: dassieu.damien@gmail.com
+    name: Damien

--- a/charts/0.4.8/templates/NOTES.txt
+++ b/charts/0.4.8/templates/NOTES.txt
@@ -1,0 +1,7 @@
+syngit {{ .Chart.AppVersion }} has been deployed successfully!
+
+Information on the usage of the operator can be found here:
+https://github.com/syngit-org/syngit/wiki/📖-Usage
+
+More information about Syngit on the wiki:
+https://github.com/syngit-org/syngit/wiki

--- a/charts/0.4.8/templates/certmanager/certificate.yaml
+++ b/charts/0.4.8/templates/certmanager/certificate.yaml
@@ -1,0 +1,34 @@
+{{- if eq .Values.certmanager.webhook.enabled true }}
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    app.kubernetes.io/name: certificate
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: certificate
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  name: {{ .Release.Name }}-selfsigned-issuer
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app.kubernetes.io/name: certificate
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: certificate
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  name: syngit-webhook-cert
+spec:
+  dnsNames:
+  - syngit-webhook-service.{{ .Release.Namespace }}.svc
+  - syngit-webhook-service.{{ .Release.Namespace }}.svc.local
+  issuerRef:
+    kind: Issuer
+    name: {{ .Release.Name }}-selfsigned-issuer
+  secretName: {{ .Values.certmanager.webhook.certificate.secret }}
+{{- end }}

--- a/charts/0.4.8/templates/controller/manager.yaml
+++ b/charts/0.4.8/templates/controller/manager.yaml
@@ -1,0 +1,82 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  labels:
+    control-plane: controller-manager
+    app.kubernetes.io/name: deployment
+    app.kubernetes.io/version: {{ .Chart.Version }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: manager
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+spec:
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  replicas: {{ .Values.controller.replicas }}
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        control-plane: controller-manager
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/version: {{ .Chart.Version }}
+    spec:
+      {{- if .Values.controller.image.imagePullSecrets }}
+      imagePullSecrets:
+        {{ toYaml .Values.controller.image.imagePullSecrets | nindent 8 }}
+      {{- end }}
+      containers:
+      - command:
+        - /manager
+        {{- if .Values.controller.image.imagePullPolicy }}
+        imagePullPolicy: {{ .Values.controller.image.imagePullPolicy }}
+        {{- end }}
+        args:
+        - "--leader-elect"
+        - "--health-probe-bind-address=:8081"
+        - "--metrics-bind-address=:8443"
+        image: {{ .Values.controller.image.prefix }}/{{ .Values.controller.image.name }}:{{ .Values.controller.image.tag }}
+        env:
+        - name: MANAGER_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: DYNAMIC_WEBHOOK_NAME
+          value: {{ .Release.Name }}-dynamic-remotesyncer-webhook
+        name: manager
+        securityContext: {{ toYaml .Values.controller.securityContext | nindent 10 }}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources: {{ toYaml .Values.controller.resources | nindent 10 }}
+        ports:
+        - containerPort: 9443
+          name: webhook-svc
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      serviceAccountName: {{ .Release.Name }}-controller-manager
+      terminationGracePeriodSeconds: 10
+      {{- if .Values.controller.tolerations }}
+      tolerations: {{ toYaml .Values.controller.tolerations | nindent 8 }}
+      {{- end }}
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: {{ .Values.certmanager.webhook.certificate.secret }}

--- a/charts/0.4.8/templates/controller/metrics_service.yaml
+++ b/charts/0.4.8/templates/controller/metrics_service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    control-plane: controller-manager
+    app.kubernetes.io/name: service
+    app.kubernetes.io/managed-by: kustomize
+  name: controller-manager-metrics-service
+  namespace: {{ .Release.Namespace }}
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    control-plane: controller-manager

--- a/charts/0.4.8/templates/crd/syngit.io_remotesyncer.yaml
+++ b/charts/0.4.8/templates/crd/syngit.io_remotesyncer.yaml
@@ -1,0 +1,1338 @@
+{{- if eq .Values.crds.enabled true }}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+    {{- if eq .Values.certmanager.webhook.enabled true }}
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/syngit-webhook-cert
+    {{- end }}
+  name: remotesyncers.syngit.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          namespace: {{ .Release.Namespace }}
+          name: syngit-webhook-service
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1
+  group: syngit.io
+  names:
+    categories:
+    - syngit
+    kind: RemoteSyncer
+    listKind: RemoteSyncerList
+    plural: remotesyncers
+    shortNames:
+    - rsy
+    - rsys
+    singular: remotesyncer
+  scope: Namespaced
+  versions:
+  - name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: RemoteSyncer is the Schema for the remotesyncers API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: RemoteSyncerSpec defines the desired state of RemoteSyncer
+            properties:
+              bypassInterceptionSubjects:
+                items:
+                  description: |-
+                    Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,
+                    or a value for non-objects such as user and group names.
+                  properties:
+                    apiGroup:
+                      description: |-
+                        APIGroup holds the API group of the referenced subject.
+                        Defaults to "" for ServiceAccount subjects.
+                        Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                      type: string
+                    kind:
+                      description: |-
+                        Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount".
+                        If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                      type: string
+                    name:
+                      description: Name of the object being referenced.
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty
+                        the Authorizer should report an error.
+                      type: string
+                  required:
+                  - kind
+                  - name
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
+              caBundleSecretRef:
+                description: |-
+                  SecretReference represents a Secret Reference. It has enough information to retrieve secret
+                  in any namespace
+                properties:
+                  name:
+                    description: name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              defaultBlockAppliedMessage:
+                type: string
+              defaultBranch:
+                example: main
+                type: string
+              defaultRemoteUserRef:
+                description: |-
+                  ObjectReference contains enough information to let you inspect or modify the referred object.
+                  ---
+                  New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.
+                   1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.
+                   2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular
+                      restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".
+                      Those cannot be well described when embedded.
+                   3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.
+                   4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity
+                      during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple
+                      and the version of the actual struct is irrelevant.
+                   5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type
+                      will affect numerous schemas.  Don't make new APIs embed an underspecified API type they do not control.
+
+
+                  Instead of using this type, create a locally provided and used type that is well-focused on your reference.
+                  For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                      TODO: this design is not final and this field is subject to change in the future.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              defaultUnauthorizedUserMode:
+                default: Block
+                enum:
+                - Block
+                - UseDefaultUser
+                type: string
+              excludedFields:
+                items:
+                  type: string
+                type: array
+              excludedFieldsConfig:
+                description: |-
+                  ObjectReference contains enough information to let you inspect or modify the referred object.
+                  ---
+                  New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.
+                   1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.
+                   2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular
+                      restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".
+                      Those cannot be well described when embedded.
+                   3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.
+                   4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity
+                      during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple
+                      and the version of the actual struct is irrelevant.
+                   5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type
+                      will affect numerous schemas.  Don't make new APIs embed an underspecified API type they do not control.
+
+
+                  Instead of using this type, create a locally provided and used type that is well-focused on your reference.
+                  For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                      TODO: this design is not final and this field is subject to change in the future.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              insecureSkipTlsVerify:
+                type: boolean
+              processMode:
+                default: CommitApply
+                enum:
+                - CommitOnly
+                - CommitApply
+                type: string
+              pushMode:
+                default: SameBranch
+                enum:
+                - SameBranch
+                - MultipleBranch
+                - MergeRequest
+                type: string
+              remoteRepository:
+                example: https://git.example.com/my-repo.git
+                format: uri
+                type: string
+              rootPath:
+                type: string
+              scopedResources:
+                default: {}
+                properties:
+                  matchPolicy:
+                    description: MatchPolicyType specifies the type of match policy.
+                    type: string
+                  objectSelector:
+                    description: |-
+                      A label selector is a label query over a set of resources. The result of matchLabels and
+                      matchExpressions are ANDed. An empty label selector matches all objects. A null
+                      label selector matches no objects.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced during a strategic
+                                merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  rules:
+                    items:
+                      description: |-
+                        RuleWithOperations is a tuple of Operations and Resources. It is recommended to make
+                        sure that all the tuple expansions are valid.
+                      properties:
+                        apiGroups:
+                          description: |-
+                            APIGroups is the API groups the resources belong to. '*' is all groups.
+                            If '*' is present, the length of the slice must be one.
+                            Required.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        apiVersions:
+                          description: |-
+                            APIVersions is the API versions the resources belong to. '*' is all versions.
+                            If '*' is present, the length of the slice must be one.
+                            Required.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        operations:
+                          description: |-
+                            Operations is the operations the admission hook cares about - CREATE, UPDATE, DELETE, CONNECT or *
+                            for all of those operations and any future admission operations that are added.
+                            If '*' is present, the length of the slice must be one.
+                            Required.
+                          items:
+                            description: OperationType specifies an operation for
+                              a request.
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        resources:
+                          description: |-
+                            Resources is a list of resources this rule applies to.
+
+
+                            For example:
+                            'pods' means pods.
+                            'pods/log' means the log subresource of pods.
+                            '*' means all resources, but not subresources.
+                            'pods/*' means all subresources of pods.
+                            '*/scale' means all scale subresources.
+                            '*/*' means all resources and their subresources.
+
+
+                            If wildcard is present, the validation rule will ensure resources do not
+                            overlap with each other.
+
+
+                            Depending on the enclosing object, subresources might not be allowed.
+                            Required.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        scope:
+                          description: |-
+                            scope specifies the scope of this rule.
+                            Valid values are "Cluster", "Namespaced", and "*"
+                            "Cluster" means that only cluster-scoped resources will match this rule.
+                            Namespace API objects are cluster-scoped.
+                            "Namespaced" means that only namespaced resources will match this rule.
+                            "*" means that there are no scope restrictions.
+                            Subresources match the scope of their parent resource.
+                            Default is "*".
+                          type: string
+                      type: object
+                    type: array
+                type: object
+            required:
+            - defaultUnauthorizedUserMode
+            - processMode
+            - pushMode
+            - remoteRepository
+            - scopedResources
+            type: object
+          status:
+            properties:
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              lastBypassedObjectState:
+                properties:
+                  lastBypassObject:
+                    properties:
+                      group:
+                        type: string
+                      name:
+                        type: string
+                      resource:
+                        type: string
+                      version:
+                        type: string
+                    required:
+                    - group
+                    - name
+                    - resource
+                    - version
+                    type: object
+                  lastBypassObjectTime:
+                    format: date-time
+                    type: string
+                  lastBypassObjectUserInfo:
+                    description: |-
+                      UserInfo holds the information about the user needed to implement the
+                      user.Info interface.
+                    properties:
+                      extra:
+                        additionalProperties:
+                          description: ExtraValue masks the value so protobuf can
+                            generate
+                          items:
+                            type: string
+                          type: array
+                        description: Any additional information provided by the authenticator.
+                        type: object
+                      groups:
+                        description: The names of groups this user is a part of.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      uid:
+                        description: |-
+                          A unique value that identifies this user across time. If this user is
+                          deleted and another user by the same name is added, they will have
+                          different UIDs.
+                        type: string
+                      username:
+                        description: The name that uniquely identifies this user among
+                          all active users.
+                        type: string
+                    type: object
+                type: object
+              lastObservedObjectState:
+                properties:
+                  lastObservedObject:
+                    properties:
+                      group:
+                        type: string
+                      name:
+                        type: string
+                      resource:
+                        type: string
+                      version:
+                        type: string
+                    required:
+                    - group
+                    - name
+                    - resource
+                    - version
+                    type: object
+                  lastObservedObjectTime:
+                    format: date-time
+                    type: string
+                  lastObservedObjectUserInfo:
+                    description: |-
+                      UserInfo holds the information about the user needed to implement the
+                      user.Info interface.
+                    properties:
+                      extra:
+                        additionalProperties:
+                          description: ExtraValue masks the value so protobuf can
+                            generate
+                          items:
+                            type: string
+                          type: array
+                        description: Any additional information provided by the authenticator.
+                        type: object
+                      groups:
+                        description: The names of groups this user is a part of.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      uid:
+                        description: |-
+                          A unique value that identifies this user across time. If this user is
+                          deleted and another user by the same name is added, they will have
+                          different UIDs.
+                        type: string
+                      username:
+                        description: The name that uniquely identifies this user among
+                          all active users.
+                        type: string
+                    type: object
+                type: object
+              lastPushedObjectState:
+                properties:
+                  lastPushedGitUser:
+                    type: string
+                  lastPushedObject:
+                    properties:
+                      group:
+                        type: string
+                      name:
+                        type: string
+                      resource:
+                        type: string
+                      version:
+                        type: string
+                    required:
+                    - group
+                    - name
+                    - resource
+                    - version
+                    type: object
+                  lastPushedObjectCommitHash:
+                    type: string
+                  lastPushedObjectGitPath:
+                    type: string
+                  lastPushedObjectGitRepo:
+                    type: string
+                  lastPushedObjectState:
+                    type: string
+                  lastPushedObjectTime:
+                    format: date-time
+                    type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1beta3
+    schema:
+      openAPIV3Schema:
+        description: RemoteSyncer is the Schema for the remotesyncers API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: RemoteSyncerSpec defines the desired state of RemoteSyncer
+            properties:
+              bypassInterceptionSubjects:
+                items:
+                  description: |-
+                    Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,
+                    or a value for non-objects such as user and group names.
+                  properties:
+                    apiGroup:
+                      description: |-
+                        APIGroup holds the API group of the referenced subject.
+                        Defaults to "" for ServiceAccount subjects.
+                        Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                      type: string
+                    kind:
+                      description: |-
+                        Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount".
+                        If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                      type: string
+                    name:
+                      description: Name of the object being referenced.
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty
+                        the Authorizer should report an error.
+                      type: string
+                  required:
+                  - kind
+                  - name
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
+              caBundleSecretRef:
+                description: |-
+                  SecretReference represents a Secret Reference. It has enough information to retrieve secret
+                  in any namespace
+                properties:
+                  name:
+                    description: name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              defaultBlockAppliedMessage:
+                type: string
+              defaultBranch:
+                default: main
+                example: main
+                type: string
+              defaultRemoteTargetRef:
+                description: |-
+                  ObjectReference contains enough information to let you inspect or modify the referred object.
+                  ---
+                  New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.
+                   1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.
+                   2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular
+                      restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".
+                      Those cannot be well described when embedded.
+                   3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.
+                   4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity
+                      during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple
+                      and the version of the actual struct is irrelevant.
+                   5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type
+                      will affect numerous schemas.  Don't make new APIs embed an underspecified API type they do not control.
+
+
+                  Instead of using this type, create a locally provided and used type that is well-focused on your reference.
+                  For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                      TODO: this design is not final and this field is subject to change in the future.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              defaultRemoteUserRef:
+                description: |-
+                  ObjectReference contains enough information to let you inspect or modify the referred object.
+                  ---
+                  New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.
+                   1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.
+                   2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular
+                      restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".
+                      Those cannot be well described when embedded.
+                   3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.
+                   4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity
+                      during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple
+                      and the version of the actual struct is irrelevant.
+                   5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type
+                      will affect numerous schemas.  Don't make new APIs embed an underspecified API type they do not control.
+
+
+                  Instead of using this type, create a locally provided and used type that is well-focused on your reference.
+                  For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                      TODO: this design is not final and this field is subject to change in the future.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              defaultUnauthorizedUserMode:
+                default: Block
+                enum:
+                - Block
+                - UseDefaultUser
+                type: string
+              excludedFields:
+                items:
+                  type: string
+                type: array
+              excludedFieldsConfig:
+                description: |-
+                  ObjectReference contains enough information to let you inspect or modify the referred object.
+                  ---
+                  New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.
+                   1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.
+                   2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular
+                      restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".
+                      Those cannot be well described when embedded.
+                   3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.
+                   4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity
+                      during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple
+                      and the version of the actual struct is irrelevant.
+                   5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type
+                      will affect numerous schemas.  Don't make new APIs embed an underspecified API type they do not control.
+
+
+                  Instead of using this type, create a locally provided and used type that is well-focused on your reference.
+                  For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                      TODO: this design is not final and this field is subject to change in the future.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              insecureSkipTlsVerify:
+                type: boolean
+              remoteRepository:
+                example: https://git.example.com/my-repo.git
+                format: uri
+                type: string
+              remoteTargetSelector:
+                description: |-
+                  A label selector is a label query over a set of resources. The result of matchLabels and
+                  matchExpressions are ANDed. An empty label selector matches all objects. A null
+                  label selector matches no objects.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              remoteUserBindingSelector:
+                description: |-
+                  A label selector is a label query over a set of resources. The result of matchLabels and
+                  matchExpressions are ANDed. An empty label selector matches all objects. A null
+                  label selector matches no objects.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              rootPath:
+                type: string
+              scopedResources:
+                default: {}
+                properties:
+                  matchPolicy:
+                    description: MatchPolicyType specifies the type of match policy.
+                    type: string
+                  objectSelector:
+                    description: |-
+                      A label selector is a label query over a set of resources. The result of matchLabels and
+                      matchExpressions are ANDed. An empty label selector matches all objects. A null
+                      label selector matches no objects.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced during a strategic
+                                merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  rules:
+                    items:
+                      description: |-
+                        RuleWithOperations is a tuple of Operations and Resources. It is recommended to make
+                        sure that all the tuple expansions are valid.
+                      properties:
+                        apiGroups:
+                          description: |-
+                            APIGroups is the API groups the resources belong to. '*' is all groups.
+                            If '*' is present, the length of the slice must be one.
+                            Required.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        apiVersions:
+                          description: |-
+                            APIVersions is the API versions the resources belong to. '*' is all versions.
+                            If '*' is present, the length of the slice must be one.
+                            Required.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        operations:
+                          description: |-
+                            Operations is the operations the admission hook cares about - CREATE, UPDATE, DELETE, CONNECT or *
+                            for all of those operations and any future admission operations that are added.
+                            If '*' is present, the length of the slice must be one.
+                            Required.
+                          items:
+                            description: OperationType specifies an operation for
+                              a request.
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        resources:
+                          description: |-
+                            Resources is a list of resources this rule applies to.
+
+
+                            For example:
+                            'pods' means pods.
+                            'pods/log' means the log subresource of pods.
+                            '*' means all resources, but not subresources.
+                            'pods/*' means all subresources of pods.
+                            '*/scale' means all scale subresources.
+                            '*/*' means all resources and their subresources.
+
+
+                            If wildcard is present, the validation rule will ensure resources do not
+                            overlap with each other.
+
+
+                            Depending on the enclosing object, subresources might not be allowed.
+                            Required.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        scope:
+                          description: |-
+                            scope specifies the scope of this rule.
+                            Valid values are "Cluster", "Namespaced", and "*"
+                            "Cluster" means that only cluster-scoped resources will match this rule.
+                            Namespace API objects are cluster-scoped.
+                            "Namespaced" means that only namespaced resources will match this rule.
+                            "*" means that there are no scope restrictions.
+                            Subresources match the scope of their parent resource.
+                            Default is "*".
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              strategy:
+                default: CommitApply
+                enum:
+                - CommitOnly
+                - CommitApply
+                type: string
+              targetStrategy:
+                default: OneTarget
+                enum:
+                - OneTarget
+                - MultipleTarget
+                type: string
+            required:
+            - defaultBranch
+            - defaultUnauthorizedUserMode
+            - remoteRepository
+            - scopedResources
+            - strategy
+            - targetStrategy
+            type: object
+          status:
+            properties:
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              lastBypassedObjectState:
+                properties:
+                  lastBypassObject:
+                    properties:
+                      group:
+                        type: string
+                      name:
+                        type: string
+                      resource:
+                        type: string
+                      version:
+                        type: string
+                    required:
+                    - group
+                    - name
+                    - resource
+                    - version
+                    type: object
+                  lastBypassObjectTime:
+                    format: date-time
+                    type: string
+                  lastBypassObjectUserInfo:
+                    description: |-
+                      UserInfo holds the information about the user needed to implement the
+                      user.Info interface.
+                    properties:
+                      extra:
+                        additionalProperties:
+                          description: ExtraValue masks the value so protobuf can
+                            generate
+                          items:
+                            type: string
+                          type: array
+                        description: Any additional information provided by the authenticator.
+                        type: object
+                      groups:
+                        description: The names of groups this user is a part of.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      uid:
+                        description: |-
+                          A unique value that identifies this user across time. If this user is
+                          deleted and another user by the same name is added, they will have
+                          different UIDs.
+                        type: string
+                      username:
+                        description: The name that uniquely identifies this user among
+                          all active users.
+                        type: string
+                    type: object
+                type: object
+              lastObservedObjectState:
+                properties:
+                  lastObservedObject:
+                    properties:
+                      group:
+                        type: string
+                      name:
+                        type: string
+                      resource:
+                        type: string
+                      version:
+                        type: string
+                    required:
+                    - group
+                    - name
+                    - resource
+                    - version
+                    type: object
+                  lastObservedObjectTime:
+                    format: date-time
+                    type: string
+                  lastObservedObjectUsername:
+                    type: string
+                type: object
+              lastPushedObjectState:
+                properties:
+                  lastPushedGitUser:
+                    type: string
+                  lastPushedObject:
+                    properties:
+                      group:
+                        type: string
+                      name:
+                        type: string
+                      resource:
+                        type: string
+                      version:
+                        type: string
+                    required:
+                    - group
+                    - name
+                    - resource
+                    - version
+                    type: object
+                  lastPushedObjectCommitHash:
+                    items:
+                      type: string
+                    type: array
+                  lastPushedObjectGitPath:
+                    type: string
+                  lastPushedObjectGitRepo:
+                    items:
+                      type: string
+                    type: array
+                  lastPushedObjectState:
+                    type: string
+                  lastPushedObjectTime:
+                    format: date-time
+                    type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+{{- end }}

--- a/charts/0.4.8/templates/crd/syngit.io_remotetargets.yaml
+++ b/charts/0.4.8/templates/crd/syngit.io_remotetargets.yaml
@@ -1,0 +1,174 @@
+{{- if eq .Values.crds.enabled true }}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+    {{- if eq .Values.certmanager.webhook.enabled true }}
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/syngit-webhook-cert
+    {{- end }}
+  name: remotetargets.syngit.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          namespace: {{ .Release.Namespace }}
+          name: syngit-webhook-service
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1
+  group: syngit.io
+  names:
+    categories:
+    - syngit
+    kind: RemoteTarget
+    listKind: RemoteTargetList
+    plural: remotetargets
+    shortNames:
+    - rt
+    - rts
+    singular: remotetarget
+  scope: Namespaced
+  versions:
+  - name: v1beta3
+    schema:
+      openAPIV3Schema:
+        description: RemoteTarget is the Schema for the remotetargets API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: RemoteTargetSpec defines the desired state of RemoteTarget.
+            properties:
+              mergeStrategy:
+                enum:
+                - TryFastForwardOrDie
+                - TryFastForwardOrHardReset
+                - TryHardResetOrDie
+                - ""
+                type: string
+              targetBranch:
+                type: string
+              targetRepository:
+                example: https://git.example.com/my-target-repo.git
+                format: uri
+                type: string
+              upstreamBranch:
+                type: string
+              upstreamRepository:
+                example: https://git.example.com/my-upstream-repo.git
+                format: uri
+                type: string
+            required:
+            - targetBranch
+            - targetRepository
+            - upstreamBranch
+            - upstreamRepository
+            type: object
+          status:
+            description: RemoteTargetStatus defines the observed state of RemoteTarget.
+            properties:
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              lastConsistencyOperationTime:
+                type: string
+              lastConsistencyOperationType:
+                type: string
+              lastObservedCommitHash:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+{{- end }}

--- a/charts/0.4.8/templates/crd/syngit.io_remoteuser.yaml
+++ b/charts/0.4.8/templates/crd/syngit.io_remoteuser.yaml
@@ -1,0 +1,321 @@
+{{- if eq .Values.crds.enabled true }}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+    {{- if eq .Values.certmanager.webhook.enabled true }}
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/syngit-webhook-cert
+    {{- end }}
+  name: remoteusers.syngit.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          namespace: {{ .Release.Namespace }}
+          name: syngit-webhook-service
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1
+  group: syngit.io
+  names:
+    categories:
+    - syngit
+    kind: RemoteUser
+    listKind: RemoteUserList
+    plural: remoteusers
+    shortNames:
+    - ru
+    - rus
+    singular: remoteuser
+  scope: Namespaced
+  versions:
+  - name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: RemoteUser is the Schema for the remoteusers API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              email:
+                type: string
+              gitBaseDomainFQDN:
+                type: string
+              secretRef:
+                description: |-
+                  SecretReference represents a Secret Reference. It has enough information to retrieve secret
+                  in any namespace
+                properties:
+                  name:
+                    description: name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+            required:
+            - email
+            - gitBaseDomainFQDN
+            - secretRef
+            type: object
+          status:
+            properties:
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              connexionStatus:
+                properties:
+                  details:
+                    type: string
+                  status:
+                    type: string
+                type: object
+              gitUser:
+                type: string
+              lastAuthTime:
+                format: date-time
+                type: string
+              secretBoundStatus:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1beta3
+    schema:
+      openAPIV3Schema:
+        description: RemoteUser is the Schema for the remoteusers API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              email:
+                type: string
+              gitBaseDomainFQDN:
+                type: string
+              secretRef:
+                description: |-
+                  SecretReference represents a Secret Reference. It has enough information to retrieve secret
+                  in any namespace
+                properties:
+                  name:
+                    description: name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+            required:
+            - email
+            - gitBaseDomainFQDN
+            - secretRef
+            type: object
+          status:
+            properties:
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              connexionStatus:
+                properties:
+                  details:
+                    type: string
+                  status:
+                    type: string
+                type: object
+              gitUser:
+                type: string
+              lastAuthTime:
+                format: date-time
+                type: string
+              secretBoundStatus:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+{{- end }}

--- a/charts/0.4.8/templates/crd/syngit.io_remoteuserbinding.yaml
+++ b/charts/0.4.8/templates/crd/syngit.io_remoteuserbinding.yaml
@@ -1,0 +1,504 @@
+{{- if eq .Values.crds.enabled true }}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+    {{- if eq .Values.certmanager.webhook.enabled true }}
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/syngit-webhook-cert
+    {{- end }}
+  name: remoteuserbindings.syngit.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          namespace: {{ .Release.Namespace }}
+          name: syngit-webhook-service
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1
+  group: syngit.io
+  names:
+    categories:
+    - syngit
+    kind: RemoteUserBinding
+    listKind: RemoteUserBindingList
+    plural: remoteuserbindings
+    shortNames:
+    - rub
+    - rubs
+    singular: remoteuserbinding
+  scope: Namespaced
+  versions:
+  - name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: RemoteUserBinding is the Schema for the remoteuserbindings API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              remoteRefs:
+                items:
+                  description: |-
+                    ObjectReference contains enough information to let you inspect or modify the referred object.
+                    ---
+                    New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.
+                     1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.
+                     2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular
+                        restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".
+                        Those cannot be well described when embedded.
+                     3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.
+                     4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity
+                        during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple
+                        and the version of the actual struct is irrelevant.
+                     5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type
+                        will affect numerous schemas.  Don't make new APIs embed an underspecified API type they do not control.
+
+
+                    Instead of using this type, create a locally provided and used type that is well-focused on your reference.
+                    For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: |-
+                        If referring to a piece of an object instead of an entire object, this string
+                        should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within a pod, this would take on a value like:
+                        "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]" (container with
+                        index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                        referencing a part of an object.
+                        TODO: this design is not final and this field is subject to change in the future.
+                      type: string
+                    kind:
+                      description: |-
+                        Kind of the referent.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                      type: string
+                    name:
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                      type: string
+                    resourceVersion:
+                      description: |-
+                        Specific resourceVersion to which this reference is made, if any.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                      type: string
+                    uid:
+                      description: |-
+                        UID of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
+              subject:
+                description: |-
+                  Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,
+                  or a value for non-objects such as user and group names.
+                properties:
+                  apiGroup:
+                    description: |-
+                      APIGroup holds the API group of the referenced subject.
+                      Defaults to "" for ServiceAccount subjects.
+                      Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount".
+                      If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                    type: string
+                  name:
+                    description: Name of the object being referenced.
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty
+                      the Authorizer should report an error.
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+            required:
+            - remoteRefs
+            - subject
+            type: object
+          status:
+            properties:
+              gitUserHosts:
+                items:
+                  properties:
+                    gitFQDN:
+                      type: string
+                    lastUsedTime:
+                      format: date-time
+                      type: string
+                    remoteUserUsed:
+                      type: string
+                    secretRef:
+                      description: |-
+                        SecretReference represents a Secret Reference. It has enough information to retrieve secret
+                        in any namespace
+                      properties:
+                        name:
+                          description: name is unique within a namespace to reference
+                            a secret resource.
+                          type: string
+                        namespace:
+                          description: namespace defines the space within which the
+                            secret name must be unique.
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    state:
+                      type: string
+                  required:
+                  - secretRef
+                  type: object
+                type: array
+              lastUsedTime:
+                format: date-time
+                type: string
+              state:
+                type: string
+              userKubernetesID:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1beta3
+    schema:
+      openAPIV3Schema:
+        description: RemoteUserBinding is the Schema for the remoteuserbindings API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              remoteTargetRefs:
+                items:
+                  description: |-
+                    ObjectReference contains enough information to let you inspect or modify the referred object.
+                    ---
+                    New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.
+                     1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.
+                     2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular
+                        restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".
+                        Those cannot be well described when embedded.
+                     3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.
+                     4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity
+                        during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple
+                        and the version of the actual struct is irrelevant.
+                     5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type
+                        will affect numerous schemas.  Don't make new APIs embed an underspecified API type they do not control.
+
+
+                    Instead of using this type, create a locally provided and used type that is well-focused on your reference.
+                    For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: |-
+                        If referring to a piece of an object instead of an entire object, this string
+                        should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within a pod, this would take on a value like:
+                        "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]" (container with
+                        index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                        referencing a part of an object.
+                        TODO: this design is not final and this field is subject to change in the future.
+                      type: string
+                    kind:
+                      description: |-
+                        Kind of the referent.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                      type: string
+                    name:
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                      type: string
+                    resourceVersion:
+                      description: |-
+                        Specific resourceVersion to which this reference is made, if any.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                      type: string
+                    uid:
+                      description: |-
+                        UID of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
+              remoteUserRefs:
+                items:
+                  description: |-
+                    ObjectReference contains enough information to let you inspect or modify the referred object.
+                    ---
+                    New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.
+                     1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.
+                     2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular
+                        restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".
+                        Those cannot be well described when embedded.
+                     3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.
+                     4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity
+                        during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple
+                        and the version of the actual struct is irrelevant.
+                     5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type
+                        will affect numerous schemas.  Don't make new APIs embed an underspecified API type they do not control.
+
+
+                    Instead of using this type, create a locally provided and used type that is well-focused on your reference.
+                    For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: |-
+                        If referring to a piece of an object instead of an entire object, this string
+                        should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within a pod, this would take on a value like:
+                        "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]" (container with
+                        index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                        referencing a part of an object.
+                        TODO: this design is not final and this field is subject to change in the future.
+                      type: string
+                    kind:
+                      description: |-
+                        Kind of the referent.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                      type: string
+                    name:
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                      type: string
+                    resourceVersion:
+                      description: |-
+                        Specific resourceVersion to which this reference is made, if any.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                      type: string
+                    uid:
+                      description: |-
+                        UID of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
+              subject:
+                description: |-
+                  Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,
+                  or a value for non-objects such as user and group names.
+                properties:
+                  apiGroup:
+                    description: |-
+                      APIGroup holds the API group of the referenced subject.
+                      Defaults to "" for ServiceAccount subjects.
+                      Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount".
+                      If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                    type: string
+                  name:
+                    description: Name of the object being referenced.
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty
+                      the Authorizer should report an error.
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+            required:
+            - remoteUserRefs
+            - subject
+            type: object
+          status:
+            properties:
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              gitUserHosts:
+                items:
+                  properties:
+                    gitFQDN:
+                      type: string
+                    lastUsedTime:
+                      format: date-time
+                      type: string
+                    remoteUserUsed:
+                      type: string
+                    secretRef:
+                      description: |-
+                        SecretReference represents a Secret Reference. It has enough information to retrieve secret
+                        in any namespace
+                      properties:
+                        name:
+                          description: name is unique within a namespace to reference
+                            a secret resource.
+                          type: string
+                        namespace:
+                          description: namespace defines the space within which the
+                            secret name must be unique.
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    state:
+                      type: string
+                  required:
+                  - secretRef
+                  type: object
+                type: array
+              lastUsedTime:
+                format: date-time
+                type: string
+              state:
+                type: string
+              userKubernetesID:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+{{- end }}

--- a/charts/0.4.8/templates/default/excluded-fields-cm.yaml
+++ b/charts/0.4.8/templates/default/excluded-fields-cm.yaml
@@ -1,0 +1,19 @@
+{{- if eq .Values.config.defaultExcludedFields.enabled true }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: default-excluded-fields
+  namespace: {{ .Release.Namespace }}
+  labels:
+    syngit.io/cluster-default-excluded-fields: "true"
+data:
+  excludedFields: |
+    - metadata.annotations.[kubectl.kubernetes.io/last-applied-configuration]
+    - metadata.creationTimestamp
+    - metadata.generateName
+    - metadata.generation
+    - metadata.managedFields
+    - metadata.resourceVersion
+    - metadata.uid
+    - status
+{{- end }}

--- a/charts/0.4.8/templates/monitoring/monitor.yaml
+++ b/charts/0.4.8/templates/monitoring/monitor.yaml
@@ -1,0 +1,25 @@
+{{- if eq .Values.monitoring.enabled true }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    control-plane: controller-manager
+    app.kubernetes.io/name: servicemonitor
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  name: {{ .Release.Name }}-controller-manager-metrics-monitor
+spec:
+  endpoints:
+    - path: /metrics
+      port: https
+      scheme: https
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        insecureSkipVerify: true
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+{{- end }}

--- a/charts/0.4.8/templates/network-policy/allow-metrics-traffic.yaml
+++ b/charts/0.4.8/templates/network-policy/allow-metrics-traffic.yaml
@@ -1,0 +1,23 @@
+# This NetworkPolicy allows ingress traffic
+# with Pods running on namespaces labeled with 'metrics: enabled'. Only Pods on those
+# namespaces are able to gathering data from the metrics endpoint.
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-syngit-metrics-traffic
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+  policyTypes:
+    - Ingress
+  ingress:
+    # This allows ingress traffic from any namespace with the label metrics: enabled
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            metrics: enabled  # Only from namespaces with this label
+      ports:
+        - port: 8443
+          protocol: TCP

--- a/charts/0.4.8/templates/network-policy/allow-webhook-traffic.yaml
+++ b/charts/0.4.8/templates/network-policy/allow-webhook-traffic.yaml
@@ -1,0 +1,23 @@
+# This NetworkPolicy allows ingress traffic to your webhook server running
+# as part of the controller-manager from specific namespaces and pods. CR(s) which uses webhooks
+# will only work when applied in namespaces labeled with 'webhook: enabled'
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-syngit-webhook-traffic
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+  policyTypes:
+    - Ingress
+  ingress:
+    # This allows ingress traffic from any namespace with the label webhook: enabled
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            webhook: enabled # Only from namespaces with this label
+      ports:
+        - port: 443
+          protocol: TCP

--- a/charts/0.4.8/templates/post-migration/post-migration-rbac.yaml
+++ b/charts/0.4.8/templates/post-migration/post-migration-rbac.yaml
@@ -1,0 +1,98 @@
+{{- if .Release.IsUpgrade -}}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: post-migration
+  labels:
+    app.kubernetes.io/name: job
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: post-migration
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: post-migration
+  labels:
+    app.kubernetes.io/name: job
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: helm-post-migration
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - "users"
+  - "groups"
+  verbs:
+  - "impersonate"
+- apiGroups:
+  - ""
+  - "syngit.io"
+  resources:
+  - "pods"
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "syngit.io"
+  resources:
+  - remoteusers
+  verbs:
+  - update
+  - patch
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "syngit.io"
+  resources:
+  - remotetargets
+  - remoteuserbindings
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: post-migration
+  labels:
+    app.kubernetes.io/name: job
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: helm-post-migration
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: post-migration
+subjects:
+  - kind: ServiceAccount
+    name: post-migration
+    namespace: {{ .Release.Namespace }}
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: syngit:post-migration-patch
+{{- end }}

--- a/charts/0.4.8/templates/post-migration/post-migration.yaml
+++ b/charts/0.4.8/templates/post-migration/post-migration.yaml
@@ -1,0 +1,102 @@
+{{- if .Release.IsUpgrade -}}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-post-migration
+  labels:
+    app.kubernetes.io/name: job
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: post-migration
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  template:
+    spec:
+      serviceAccountName: post-migration
+      automountServiceAccountToken: true
+      containers:
+        - name: post-migration
+          image: bitnami/kubectl:1.32.0
+          command:
+            - /bin/sh
+            - -c
+            - |
+              #!/bin/sh
+              set -e
+
+              kubectl wait --for=condition=ready pods -l app.kubernetes.io/instance={{ .Release.Name }} -l app.kubernetes.io/version={{ .Chart.Version }} \
+                -n {{ .Release.Namespace }} --timeout=500s
+
+              echo "Waiting for the leader to be elected..."
+              sleep 30
+
+              API_SERVER="https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}"
+              TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+              CACERT=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+
+              echo "Deleting RemoteTargets managed by syngit..."
+              kubectl delete remotetarget -l managed-by=syngit.io -A || true
+
+              echo "Fetching RemoteUserBindings managed by syngit.io..."
+              bindings=$(kubectl get remoteuserbindings -l managed-by=syngit.io -A -o json)
+
+              echo "$bindings" | jq -c '.items[]' | while read -r binding; do
+                bindingname=$(echo "$binding" | jq -r '.metadata.name')
+                username=$(echo "$binding" | jq -r '.spec.subject.name')
+                remoteusers=$(echo "$binding" | jq -c '.spec.remoteUserRefs[]')
+                namespace=$(echo "$binding" | jq -r '.metadata.namespace')
+
+                echo "Remote RemoteTarget references from the RemoteUserBinding..."
+                kubectl --token="$TOKEN" \
+                        --server="$API_SERVER" \
+                        --certificate-authority="$CACERT" \
+                        --as="$username" \
+                        --as-group="syngit:post-migration-patch" \
+                        -n "$namespace" \
+                        delete remoteuserbinding "$bindingname"
+
+                echo "Processing binding for user: $username"
+
+                echo "$remoteusers" | while read -r ref; do
+                  name=$(echo "$ref" | jq -r '.name')
+                  
+                  echo "Double-update RemoteUser $name in namespace $namespace as $username... 1"
+                  
+                  kubectl --token="$TOKEN" \
+                          --server="$API_SERVER" \
+                          --certificate-authority="$CACERT" \
+                          --as="$username" \
+                          --as-group="syngit:post-migration-patch" \
+                          -n "$namespace" \
+                          patch remoteuser "$name" --type='merge' -p '{
+                    "metadata": {
+                      "annotations": {
+                        "syngit.io/remoteuserbinding.managed": "false"
+                      }
+                    }
+                  }'
+                  
+                  echo "Double-update RemoteUser $name in namespace $namespace as $username... 2"
+
+                  kubectl --token="$TOKEN" \
+                          --server="$API_SERVER" \
+                          --certificate-authority="$CACERT" \
+                          --as="$username" \
+                          --as-group="syngit:post-migration-patch" \
+                          -n "$namespace" \
+                          patch remoteuser "$name" --type='merge' -p '{
+                    "metadata": {
+                      "annotations": {
+                        "syngit.io/remoteuserbinding.managed": "true"
+                      }
+                    }
+                  }'
+                done
+              done
+      restartPolicy: Never
+  backoffLimit: 4
+{{- end }}

--- a/charts/0.4.8/templates/providers/provider-github-controller.yaml
+++ b/charts/0.4.8/templates/providers/provider-github-controller.yaml
@@ -1,0 +1,73 @@
+{{- if eq .Values.providers.github.enabled true }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: syngit-provider-github
+  labels:
+    control-plane: syngit-provider-github
+    app.kubernetes.io/name: deployment
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: manager
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}-providers
+spec:
+  selector:
+    matchLabels:
+      control-plane: syngit-provider-github
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: github-provider-manager
+      labels:
+        control-plane: syngit-provider-github
+    spec:
+      {{- if .Values.providers.controller.imagePullSecrets }}
+      imagePullSecrets:
+        {{ toYaml .Values.providers.controller.imagePullSecrets | nindent 8 }}
+      {{- end }}
+      containers:
+      - command:
+        - /manager
+        {{- if .Values.providers.github.image.imagePullPolicy }}
+        imagePullPolicy: {{ .Values.providers.github.image.imagePullPolicy }}
+        {{- end }}
+        args:
+        - "--leader-elect"
+        - "--health-probe-bind-address=:8081"
+        - "--metrics-bind-address=:8443"
+        image: {{ .Values.providers.github.image.prefix }}/{{ .Values.providers.github.image.name }}:{{ .Values.providers.github.image.tag }}
+        env:
+        - name: MANAGER_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        name: github-provider-manager
+        securityContext: {{ toYaml .Values.providers.controller.securityContext | nindent 10 }}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources: {{ toYaml .Values.providers.controller.resources | nindent 10 }}
+        ports:
+        - containerPort: 9443
+          name: wbhk-crd-srv
+          protocol: TCP
+        - containerPort: 9444
+          name: wbhk-pusher-srv
+          protocol: TCP
+      serviceAccountName: {{ .Release.Name }}-providers-controller-manager
+      terminationGracePeriodSeconds: 10
+      {{- if .Values.providers.controller.tolerations }}
+      tolerations: {{ toYaml .Values.providers.controller.tolerations | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/0.4.8/templates/providers/provider-gitlab-controller.yaml
+++ b/charts/0.4.8/templates/providers/provider-gitlab-controller.yaml
@@ -1,0 +1,73 @@
+{{- if eq .Values.providers.gitlab.enabled true }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: syngit-provider-gitlab
+  labels:
+    control-plane: syngit-provider-gitlab
+    app.kubernetes.io/name: deployment
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: manager
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}-providers
+spec:
+  selector:
+    matchLabels:
+      control-plane: syngit-provider-gitlab
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: gitlab-provider-manager
+      labels:
+        control-plane: syngit-provider-gitlab
+    spec:
+      {{- if .Values.providers.controller.imagePullSecrets }}
+      imagePullSecrets:
+        {{ toYaml .Values.providers.controller.imagePullSecrets | nindent 8 }}
+      {{- end }}
+      containers:
+      - command:
+        - /manager
+        {{- if .Values.providers.gitlab.image.imagePullPolicy }}
+        imagePullPolicy: {{ .Values.providers.gitlab.image.imagePullPolicy }}
+        {{- end }}
+        args:
+        - "--leader-elect"
+        - "--health-probe-bind-address=:8081"
+        - "--metrics-bind-address=:8443"
+        image: {{ .Values.providers.gitlab.image.prefix }}/{{ .Values.providers.gitlab.image.name }}:{{ .Values.providers.gitlab.image.tag }}
+        env:
+        - name: MANAGER_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        name: gitlab-provider-manager
+        securityContext: {{ toYaml .Values.providers.controller.securityContext | nindent 10 }}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources: {{ toYaml .Values.providers.controller.resources | nindent 10 }}
+        ports:
+        - containerPort: 9443
+          name: wbhk-crd-srv
+          protocol: TCP
+        - containerPort: 9444
+          name: wbhk-pusher-srv
+          protocol: TCP
+      serviceAccountName: {{ .Release.Name }}-providers-controller-manager
+      terminationGracePeriodSeconds: 10
+      {{- if .Values.providers.controller.tolerations }}
+      tolerations: {{ toYaml .Values.providers.controller.tolerations | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/0.4.8/templates/providers/provider-leader_election_role.yaml
+++ b/charts/0.4.8/templates/providers/provider-leader_election_role.yaml
@@ -1,0 +1,33 @@
+{{- if or (eq .Values.providers.github.enabled true) (eq .Values.providers.gitlab.enabled true) }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/name: role
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}-providers
+  name: {{ .Release.Name }}-providers-leader-election-role
+rules:
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+{{- end }}

--- a/charts/0.4.8/templates/providers/providers-leader_election_role_binding.yaml
+++ b/charts/0.4.8/templates/providers/providers-leader_election_role_binding.yaml
@@ -1,0 +1,21 @@
+{{- if or (eq .Values.providers.github.enabled true) (eq .Values.providers.gitlab.enabled true) }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: rolebinding
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}-providers
+  name: {{ .Release.Name }}-providers-leader-election-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Release.Name }}-providers-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: {{ .Release.Name }}-providers-controller-manager
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/0.4.8/templates/providers/providers-role.yaml
+++ b/charts/0.4.8/templates/providers/providers-role.yaml
@@ -1,0 +1,97 @@
+{{- if or (eq .Values.providers.github.enabled true) (eq .Values.providers.gitlab.enabled true) }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-providers-manager-role
+  labels:
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}-providers
+rules:
+# Create and patch events related to kgio objects in any namespace
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - syngit.io
+  resources:
+  - remoteusers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - syngit.io
+  resources:
+  - remoteusers/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - syngit.io
+  resources:
+  - remoteuserbindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - syngit.io
+  resources:
+  - remoteuserbindings/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - syngit.io
+  resources:
+  - remoteuserbindings/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - syngit.io
+  resources:
+  - remotesyncers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - syngit.io
+  resources:
+  - remotesyncers/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - syngit.io
+  resources:
+  - remotesyncers/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+{{- end }}

--- a/charts/0.4.8/templates/providers/providers-role_binding.yaml
+++ b/charts/0.4.8/templates/providers/providers-role_binding.yaml
@@ -1,0 +1,21 @@
+{{- if or (eq .Values.providers.github.enabled true) (eq .Values.providers.gitlab.enabled true) }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: clusterrolebinding
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}-providers
+  name: {{ .Release.Name }}-providers-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Name }}-providers-manager-role
+subjects:
+- kind: ServiceAccount
+  name: {{ .Release.Name }}-providers-controller-manager
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/0.4.8/templates/providers/providers-service_account.yaml
+++ b/charts/0.4.8/templates/providers/providers-service_account.yaml
@@ -1,0 +1,13 @@
+{{- if or (eq .Values.providers.github.enabled true) (eq .Values.providers.gitlab.enabled true) }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/name: serviceaccount
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}-providers
+  name: {{ .Release.Name }}-providers-controller-manager
+{{- end }}

--- a/charts/0.4.8/templates/rbac/controller/leader_election_role.yaml
+++ b/charts/0.4.8/templates/rbac/controller/leader_election_role.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/name: role
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  name: {{ .Release.Name }}-leader-election-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch

--- a/charts/0.4.8/templates/rbac/controller/leader_election_role_binding.yaml
+++ b/charts/0.4.8/templates/rbac/controller/leader_election_role_binding.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: rolebinding
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  name: {{ .Release.Name }}-leader-election-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Release.Name }}-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: {{ .Release.Name }}-controller-manager
+  namespace: {{ .Release.Namespace }}

--- a/charts/0.4.8/templates/rbac/controller/role.yaml
+++ b/charts/0.4.8/templates/rbac/controller/role.yaml
@@ -1,0 +1,137 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-manager-role
+  labels:
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+rules:
+# Any resources can be pushed to the git repo.
+# The scope depends but the controller
+#  needs to be able to get,list,watch any of them
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+# Create and patch events related to kgio objects in any namespace
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - validatingwebhookconfigurations
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - syngit.io
+  resources:
+  - remoteusers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - syngit.io
+  resources:
+  - remoteusers/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - syngit.io
+  resources:
+  - remoteuserbindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - syngit.io
+  resources:
+  - remoteuserbindings/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - syngit.io
+  resources:
+  - remoteuserbindings/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - syngit.io
+  resources:
+  - remotesyncers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - syngit.io
+  resources:
+  - remotesyncers/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - syngit.io
+  resources:
+  - remotesyncers/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - syngit.io
+  resources:
+  - remotetargets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - syngit.io
+  resources:
+  - remotetargets/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create

--- a/charts/0.4.8/templates/rbac/controller/role_binding.yaml
+++ b/charts/0.4.8/templates/rbac/controller/role_binding.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: clusterrolebinding
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  name: {{ .Release.Name }}-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Name }}-manager-role
+subjects:
+- kind: ServiceAccount
+  name: {{ .Release.Name }}-controller-manager
+  namespace: {{ .Release.Namespace }}

--- a/charts/0.4.8/templates/rbac/controller/service_account.yaml
+++ b/charts/0.4.8/templates/rbac/controller/service_account.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/name: serviceaccount
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  name: {{ .Release.Name }}-controller-manager

--- a/charts/0.4.8/templates/rbac/end-user/remotesyncer_editor_role.yaml
+++ b/charts/0.4.8/templates/rbac/end-user/remotesyncer_editor_role.yaml
@@ -1,0 +1,32 @@
+{{- if eq .Values.installEndUserRoles true }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  name: {{ .Release.Name }}-remotesyncers-editor-role
+rules:
+- apiGroups:
+  - syngit.io
+  resources:
+  - remotesyncers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - syngit.io
+  resources:
+  - remotesyncers/status
+  verbs:
+  - get
+{{- end }}

--- a/charts/0.4.8/templates/rbac/end-user/remotesyncer_viewer_role.yaml
+++ b/charts/0.4.8/templates/rbac/end-user/remotesyncer_viewer_role.yaml
@@ -1,0 +1,28 @@
+{{- if eq .Values.installEndUserRoles true }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  name: {{ .Release.Name }}-remotesyncers-viewer-role
+rules:
+- apiGroups:
+  - syngit.io
+  resources:
+  - remotesyncers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - syngit.io
+  resources:
+  - remotesyncers/status
+  verbs:
+  - get
+{{- end }}

--- a/charts/0.4.8/templates/rbac/end-user/remoteuser_editor_role.yaml
+++ b/charts/0.4.8/templates/rbac/end-user/remoteuser_editor_role.yaml
@@ -1,0 +1,32 @@
+{{- if eq .Values.installEndUserRoles true }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  name: {{ .Release.Name }}-remoteuser-editor-role
+rules:
+- apiGroups:
+  - syngit.io
+  resources:
+  - remoteusers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - syngit.io
+  resources:
+  - remoteusers/status
+  verbs:
+  - get
+{{- end }}

--- a/charts/0.4.8/templates/rbac/end-user/remoteuser_viewer_role.yaml
+++ b/charts/0.4.8/templates/rbac/end-user/remoteuser_viewer_role.yaml
@@ -1,0 +1,28 @@
+{{- if eq .Values.installEndUserRoles true }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  name: {{ .Release.Name }}-gitremote-viewer-role
+rules:
+- apiGroups:
+  - syngit.io
+  resources:
+  - remoteusers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - syngit.io
+  resources:
+  - remoteusers/status
+  verbs:
+  - get
+{{- end }}

--- a/charts/0.4.8/templates/rbac/end-user/remoteuserbinding_editor_role.yaml
+++ b/charts/0.4.8/templates/rbac/end-user/remoteuserbinding_editor_role.yaml
@@ -1,0 +1,32 @@
+{{- if eq .Values.installEndUserRoles true }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  name: {{ .Release.Name }}-remoteuserbinding-editor-role
+rules:
+- apiGroups:
+  - syngit.io
+  resources:
+  - remoteuserbindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - syngit.io
+  resources:
+  - remoteuserbindings/status
+  verbs:
+  - get
+{{- end }}

--- a/charts/0.4.8/templates/rbac/end-user/remoteuserbinding_viewer_role.yaml
+++ b/charts/0.4.8/templates/rbac/end-user/remoteuserbinding_viewer_role.yaml
@@ -1,0 +1,28 @@
+{{- if eq .Values.installEndUserRoles true }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  name: {{ .Release.Name }}-remoteuserbinding-viewer-role
+rules:
+- apiGroups:
+  - syngit.io
+  resources:
+  - remoteuserbindings
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - syngit.io
+  resources:
+  - remoteuserbindings/status
+  verbs:
+  - get
+{{- end }}

--- a/charts/0.4.8/templates/startupcheck/startupcheck-job.yaml
+++ b/charts/0.4.8/templates/startupcheck/startupcheck-job.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-startupcheck
+  labels:
+    app.kubernetes.io/name: job
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: helm-startupcheck
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  template:
+    spec:
+      serviceAccountName: startupcheck
+      automountServiceAccountToken: true
+      containers:
+        - name: wait-for-controller
+          image: bitnami/kubectl:1.32.0
+          command:
+            - /bin/sh
+            - -c
+            - |
+              echo "Waiting for all pods to be Ready..."
+              kubectl wait --for=condition=ready pods -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }} --timeout=500s
+              echo "All the pods of the controller are Ready!"
+
+              echo "Waiting for the certificate to be updated..."
+              kubectl wait --for=condition=ready certificate -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }} --timeout=500s
+              echo "The certificate used for Syngit is Ready!"
+      restartPolicy: Never
+  backoffLimit: 4

--- a/charts/0.4.8/templates/startupcheck/startupcheck-rbac.yaml
+++ b/charts/0.4.8/templates/startupcheck/startupcheck-rbac.yaml
@@ -1,0 +1,61 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: startupcheck
+  labels:
+    app.kubernetes.io/name: job
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: helm-startupcheck
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: startupcheck
+  labels:
+    app.kubernetes.io/name: job
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: helm-startupcheck
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+rules:
+- apiGroups:
+  - ""
+  - "cert-manager.io"
+  resources:
+  - pods
+  - certificates
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: startupcheck
+  labels:
+    app.kubernetes.io/name: job
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: helm-startupcheck
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: startupcheck
+subjects:
+  - kind: ServiceAccount
+    name: startupcheck
+    namespace: {{ .Release.Namespace }}

--- a/charts/0.4.8/templates/webhook/webhook-service.yaml
+++ b/charts/0.4.8/templates/webhook/webhook-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: service
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  name: syngit-webhook-service
+spec:
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 9443
+  selector:
+    control-plane: controller-manager

--- a/charts/0.4.8/templates/webhook/webhooks.yaml
+++ b/charts/0.4.8/templates/webhook/webhooks.yaml
@@ -1,0 +1,197 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: {{ .Release.Name }}-dynamic-remotesyncer-webhook
+  labels:
+    app.kubernetes.io/name: webhook
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: webhooks
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  {{- if eq .Values.certmanager.webhook.enabled true }}
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/syngit-webhook-cert
+  {{- end }}
+webhooks: []
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: {{ .Release.Name }}-validating-webhook-configuration
+  labels:
+    app.kubernetes.io/name: webhook
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: webhooks
+    app.kubernetes.io/created-by: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+  {{- if eq .Values.certmanager.webhook.enabled true }}
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/syngit-webhook-cert
+  {{- end }}
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: syngit-webhook-service
+      namespace: {{ .Release.Namespace }}
+      path: /validate-syngit-io-v1beta3-remoteuser
+  failurePolicy: Fail
+  name: vremoteuser.kb.io
+  rules:
+  - apiGroups:
+    - syngit.io
+    apiVersions:
+    - v1beta3
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - remoteusers
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: syngit-webhook-service
+      namespace: {{ .Release.Namespace }}
+      path: /syngit-v1beta3-remotesyncer-rules-permissions
+  failurePolicy: Fail
+  name: vremotesyncers-rules-permissions.v1beta3.syngit.io
+  rules:
+  - apiGroups:
+    - syngit.io
+    apiVersions:
+    - v1beta3
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - remotesyncers
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: syngit-webhook-service
+      namespace: {{ .Release.Namespace }}
+      path: /validate-syngit-io-v1beta3-remotesyncer
+  failurePolicy: Fail
+  name: vremotesyncer.kb.io
+  rules:
+  - apiGroups:
+    - syngit.io
+    apiVersions:
+    - v1beta3
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - remotesyncers
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: syngit-webhook-service
+      namespace: {{ .Release.Namespace }}
+      path: /syngit-v1beta3-remoteuserbinding-permissions
+  failurePolicy: Fail
+  name: vremoteuserbindings-permissions.v1beta3.syngit.io
+  rules:
+  - apiGroups:
+    - syngit.io
+    apiVersions:
+    - v1beta3
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - remoteuserbindings
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: syngit-webhook-service
+      namespace: {{ .Release.Namespace }}
+      path: /syngit-v1beta3-remoteuser-association
+  failurePolicy: Fail
+  name: vremoteusers-association.v1beta3.syngit.io
+  rules:
+  - apiGroups:
+    - syngit.io
+    apiVersions:
+    - v1beta3
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - remoteusers
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: syngit-webhook-service
+      namespace: {{ .Release.Namespace }}
+      path: /syngit-v1beta3-remoteuser-permissions
+  failurePolicy: Fail
+  name: vremoteusers-permissions.v1beta3.syngit.io
+  rules:
+  - apiGroups:
+    - syngit.io
+    apiVersions:
+    - v1beta3
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - remoteusers
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: syngit-webhook-service
+      namespace: {{ .Release.Namespace }}
+      path: /syngit-v1beta3-remotesyncer-target-pattern
+  failurePolicy: Fail
+  name: vremotesyncers-target-pattern.v1beta3.syngit.io
+  rules:
+  - apiGroups:
+    - syngit.io
+    apiVersions:
+    - v1beta3
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - remotesyncers
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: syngit-webhook-service
+      namespace: {{ .Release.Namespace }}
+      path: /validate-syngit-io-v1beta3-remotetarget
+  failurePolicy: Fail
+  name: vremotetarget-v1beta3.kb.io
+  rules:
+  - apiGroups:
+    - syngit.io
+    apiVersions:
+    - v1beta3
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - remotetargets
+  sideEffects: None

--- a/charts/0.4.8/values.yaml
+++ b/charts/0.4.8/values.yaml
@@ -1,0 +1,89 @@
+certmanager:
+  dependency:
+    enabled: false
+  webhook:
+    enabled: true
+    certificate:
+      name: webhook-cert
+      secret: webhook-server-cert
+
+controller:
+  image:
+    prefix: ghcr.io/syngit-org
+    name: syngit
+    tag: v0.4.8
+    # imagePullSecrets:
+    # imagePullPolicy:
+
+  replicas: 1
+
+  securityContext:
+    runAsUser: 1000
+    allowPrivilegeEscalation: false
+    privileged: false
+    runAsNonRoot: true
+    seccompProfile:
+      type: "RuntimeDefault"
+    capabilities:
+      drop:
+      - "ALL"
+  resources:
+    limits:
+      cpu: 500m
+      memory: 128Mi
+    requests:
+      cpu: 10m
+      memory: 64Mi
+  tolerations: []
+
+monitoring:
+  enabled: false
+
+crds:
+  enabled: true
+
+installEndUserRoles: true
+
+config:
+  defaultExcludedFields:
+    enabled: true
+
+providers:
+
+  controller:
+    securityContext:
+      runAsUser: 1000
+      allowPrivilegeEscalation: false
+      privileged: false
+      runAsNonRoot: true
+      seccompProfile:
+        type: "RuntimeDefault"
+      capabilities:
+        drop:
+        - "ALL"
+    resources:
+      limits:
+        cpu: 500m
+        memory: 128Mi
+      requests:
+        cpu: 10m
+        memory: 64Mi
+    tolerations: []
+
+  gitlab:
+    enabled: false
+    image:
+      prefix: ghcr.io/syngit-org
+      name: syngit-provider-gitlab
+      tag: v0.2.1
+      # imagePullSecrets:
+      # imagePullPolicy:
+
+  github:
+    enabled: false
+    image:
+      prefix: ghcr.io/syngit-org
+      name: syngit-provider-github
+      tag: v0.1.0
+      # imagePullSecrets:
+      # imagePullPolicy:

--- a/test/e2e/helm/install/e2e_suite_test.go
+++ b/test/e2e/helm/install/e2e_suite_test.go
@@ -48,8 +48,8 @@ var _ = BeforeSuite(func() {
 	By("installing prometheus operator")
 	Expect(utils.InstallPrometheusOperator()).To(Succeed())
 
-	By("installing the cert-manager")
-	Expect(utils.InstallCertManager()).To(Succeed())
+	By("installing the cert-manager CRDs")
+	Expect(utils.InstallCertManagerCRDs()).To(Succeed())
 
 	By("build the image")
 	cmd = exec.Command("make", "docker-build")
@@ -73,13 +73,13 @@ var _ = AfterSuite(func() {
 	By("uninstalling the Prometheus manager bundle")
 	utils.UninstallPrometheusOperator()
 
-	By("uninstalling the cert-manager bundle")
-	utils.UninstallCertManager()
-
 	By("uninstalling the syngit chart")
 	cmd := exec.Command("make", "chart-uninstall")
 	_, err := utils.Run(cmd)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+	By("uninstalling the cert-manager CRDs bundle")
+	utils.UninstallCertManagerCRDs()
 
 	By("removing test namespace")
 	cmd = exec.Command("kubectl", "delete", "ns", testNamespace)

--- a/test/e2e/helm/upgrade/e2e_suite_test.go
+++ b/test/e2e/helm/upgrade/e2e_suite_test.go
@@ -50,6 +50,7 @@ var _ = BeforeSuite(func() {
 	By("installing prometheus operator")
 	Expect(utils.InstallPrometheusOperator()).To(Succeed())
 
+	// TO DO: Replace the following by utils.InstallCertManagerCRDs when last stable version of syngit Helm chat is >= 0.4.8
 	By("installing the cert-manager")
 	Expect(utils.InstallCertManager()).To(Succeed())
 

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -31,7 +31,9 @@ const (
 	prometheusOperatorURL     = "https://github.com/prometheus-operator/prometheus-operator/" +
 		"releases/download/%s/bundle.yaml"
 
-	certmanagerVersion = "v1.13.3"
+	certmanagerVersion = "v1.17.2"
+	certmanagerCRDsURL = "https://github.com/cert-manager/cert-manager/releases/download/%s/cert-manager.crds.yaml"
+
 	certmanagerURLTmpl = "https://github.com/jetstack/cert-manager/releases/download/%s/cert-manager.yaml"
 )
 
@@ -90,6 +92,14 @@ func UninstallCertManager() {
 	}
 }
 
+func UninstallCertManagerCRDs() {
+	url := fmt.Sprintf(certmanagerCRDsURL, certmanagerVersion)
+	cmd := exec.Command("kubectl", "delete", "-f", url)
+	if _, err := Run(cmd); err != nil {
+		warnError(err)
+	}
+}
+
 // InstallCertManager installs the cert manager bundle.
 // func InstallCertManager() error {
 // 	url := fmt.Sprintf(certmanagerURLTmpl, certmanagerVersion)
@@ -113,13 +123,14 @@ func UninstallCertManager() {
 // 	return err
 // }
 
+// TO DO: delete following function when last stable version of syngit Helm chat is >= 0.4.8
 func InstallCertManager() error {
 	cmd := exec.Command("helm", "repo", "add", "jetstack", "https://charts.jetstack.io")
 	if _, err := Run(cmd); err != nil {
 		warnError(err)
 	}
 
-	cmd = exec.Command("helm", "install", "cert-manager", "-n", "cert-manager", "--version", "v1.16.2", "--create-namespace", "jetstack/cert-manager", "--set", "installCRDs=true")
+	cmd = exec.Command("helm", "install", "cert-manager", "-n", "cert-manager", "--version", "v1.17.2", "--create-namespace", "jetstack/cert-manager", "--set", "installCRDs=true")
 	if _, err := Run(cmd); err != nil {
 		return err
 	}
@@ -134,6 +145,17 @@ func InstallCertManager() error {
 	_, err := Run(cmd)
 	if err != nil {
 		return err
+	}
+
+	return err
+}
+
+func InstallCertManagerCRDs() error {
+	url := fmt.Sprintf(certmanagerCRDsURL, certmanagerVersion)
+	cmd := exec.Command("kubectl", "apply", "-f", url)
+	_, err := Run(cmd)
+	if err != nil {
+		warnError(err)
 	}
 
 	return err


### PR DESCRIPTION
This PR resolves #44

**Description of Changes:**

This Pull Request introduces `cert-manager` (version ~v1.17.2) as an optional Helm dependency to the Syngit chart, released as chart version `0.4.8`.

Key changes include:
- Added `cert-manager` to `Chart.yaml` under the condition `webhook.certmanager.enabled`.
- Updated `values.yaml` to:
    - Provide a `cert-manager` section to pass values to the subchart, with `installCRDs` defaulted to `false` to encourage pre-installation of CRDs by the user.
- Updated `README.md` to:
    - Explain the new optional `cert-manager` integration.
    - Detail how to enable it during Helm installation.
    - Provide strong recommendations for pre-installing `cert-manager` CRDs (v1.17.x) manually for stability, including example commands.
    - Adapt tests in consequence

**Reason for Change:**

The primary goal is to simplify the installation of Syngit on blank clusters (e.g., new Kind clusters). 

**Testing:**

- All `make test` suites pass successfully with these changes.
- The `make pre-commit-check` also passes.

**Documentation Updates:**

- The main `README.md` for the chart has been updated as detailed above.
- Comments in `values.yaml` have been updated for the new options.

Addressing @damsien as requested in the issue context.