### PR TITLE
fix(controller): concurrent update on same object

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -215,9 +215,10 @@ func main() {
 	}
 
 	if err = (&controller.AssociationPolicyReconciler{
-		Client:   mgr.GetClient(),
-		Scheme:   mgr.GetScheme(),
-		Recorder: mgr.GetEventRecorder("association-policy-controller"),
+		Client:    mgr.GetClient(),
+		APIReader: mgr.GetAPIReader(),
+		Scheme:    mgr.GetScheme(),
+		Recorder:  mgr.GetEventRecorder("association-policy-controller"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "AssociationPolicy")
 		os.Exit(1)

--- a/internal/controller/association_policy_controller.go
+++ b/internal/controller/association_policy_controller.go
@@ -31,8 +31,9 @@ const associationPolicyFinalizer = "syngit.io/association-policy"
 // that have the managed annotation set.
 type AssociationPolicyReconciler struct {
 	client.Client
-	Scheme   *runtime.Scheme
-	Recorder events.EventRecorder
+	APIReader client.Reader
+	Scheme    *runtime.Scheme
+	Recorder  events.EventRecorder
 }
 
 // +kubebuilder:rbac:groups=syngit.io,resources=remoteusers,verbs=get;list;watch;update;patch
@@ -42,7 +43,7 @@ type AssociationPolicyReconciler struct {
 
 func (r *AssociationPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
-	rdm := time.Duration(rand.New(rand.NewSource(1)).Intn(5)) * time.Second
+	rdm := time.Duration(rand.Intn(5)) * time.Second
 
 	var remoteUser syngit.RemoteUser
 	if err := r.Get(ctx, req.NamespacedName, &remoteUser); err != nil {
@@ -198,24 +199,23 @@ func (r *AssociationPolicyReconciler) findOrCreateManagedRUB(ctx context.Context
 	return nil, fmt.Errorf("could not allocate a name for managed RemoteUserBinding (base=%q)", baseName)
 }
 
-// ensureRemoteUserRef ensures the RemoteUser is in the RUB's remoteUserRefs. Returns true if modified.
+// ensureRemoteUserRef ensures the RemoteUser is in the RUB's remoteUserRefs.
 func (r *AssociationPolicyReconciler) ensureRemoteUserRef(ctx context.Context, rub *syngit.RemoteUserBinding, remoteUserName string) error {
-	for _, ref := range rub.Spec.RemoteUserRefs {
-		if ref.Name == remoteUserName {
+	return utils.MutateOrDeleteManagedRemoteUserBinding(ctx, r.Client,
+		types.NamespacedName{Name: rub.Name, Namespace: rub.Namespace},
+		func(fresh *syngit.RemoteUserBinding) error {
+			for _, ref := range fresh.Spec.RemoteUserRefs {
+				if ref.Name == remoteUserName {
+					return nil
+				}
+			}
+			fresh.Spec.RemoteUserRefs = append(fresh.Spec.RemoteUserRefs, corev1.ObjectReference{Name: remoteUserName})
 			return nil
-		}
-	}
-	if err := r.Get(ctx, types.NamespacedName{Name: rub.Name, Namespace: rub.Namespace}, rub); err != nil {
-		return err
-	}
-	rub.Spec.RemoteUserRefs = append(rub.Spec.RemoteUserRefs, corev1.ObjectReference{Name: remoteUserName})
-
-	return r.Update(ctx, rub)
+		})
 }
 
-// associateRemoteTargets finds all one-or-many-branches RemoteTargets and ensures they're in the RUB.
+// associateExistingRemoteTargets finds all one-or-many-branches RemoteTargets and ensures they're in the RUB.
 func (r *AssociationPolicyReconciler) associateExistingRemoteTargets(ctx context.Context, rub *syngit.RemoteUserBinding) error {
-	rtList := &syngit.RemoteTargetList{}
 	listOps := &client.ListOptions{
 		Namespace: rub.Namespace,
 		LabelSelector: labels.SelectorFromSet(labels.Set{
@@ -223,30 +223,19 @@ func (r *AssociationPolicyReconciler) associateExistingRemoteTargets(ctx context
 			syngit.RtLabelKeyPolicy:  syngit.RtLabelValueOneOrManyBranches,
 		}),
 	}
-	if err := r.List(ctx, rtList, listOps); err != nil {
-		return err
-	}
 
-	spec := *rub.Spec.DeepCopy()
-	modified := false
-	for _, rt := range rtList.Items {
-		found := false
-		for _, ref := range spec.RemoteTargetRefs {
-			if ref.Name == rt.Name {
-				found = true
-				break
+	return utils.MutateOrDeleteManagedRemoteUserBinding(ctx, r.Client,
+		types.NamespacedName{Name: rub.Name, Namespace: rub.Namespace},
+		func(fresh *syngit.RemoteUserBinding) error {
+			rtList := &syngit.RemoteTargetList{}
+			if err := r.APIReader.List(ctx, rtList, listOps); err != nil {
+				return err
 			}
-		}
-		if !found {
-			spec.RemoteTargetRefs = append(spec.RemoteTargetRefs, corev1.ObjectReference{Name: rt.Name})
-			modified = true
-		}
-	}
-
-	if !modified {
-		return nil
-	}
-	return utils.UpdateOrDeleteManagedRemoteUserBinding(ctx, r.Client, spec, *rub)
+			for _, rt := range rtList.Items {
+				utils.AddRemoteTargetRef(fresh, rt.Name)
+			}
+			return nil
+		})
 }
 
 // cleanupAssociation removes the RemoteUser from its managed RUB and deletes the RUB if empty.
@@ -267,20 +256,20 @@ func (r *AssociationPolicyReconciler) cleanupAssociation(ctx context.Context, re
 		return err
 	}
 
-	for _, rub := range rubList.Items {
-		newRefs := []corev1.ObjectReference{}
-		for _, ref := range rub.Spec.RemoteUserRefs {
-			if ref.Name != remoteUser.Name {
-				newRefs = append(newRefs, ref)
-			}
-		}
-		if len(newRefs) == len(rub.Spec.RemoteUserRefs) {
-			continue
-		}
-
-		spec := *rub.Spec.DeepCopy()
-		spec.RemoteUserRefs = newRefs
-		if err := utils.UpdateOrDeleteManagedRemoteUserBinding(ctx, r.Client, spec, rub); err != nil {
+	for i := range rubList.Items {
+		rub := &rubList.Items[i]
+		if err := utils.MutateOrDeleteManagedRemoteUserBinding(ctx, r.Client,
+			types.NamespacedName{Name: rub.Name, Namespace: rub.Namespace},
+			func(fresh *syngit.RemoteUserBinding) error {
+				newRefs := make([]corev1.ObjectReference, 0, len(fresh.Spec.RemoteUserRefs))
+				for _, ref := range fresh.Spec.RemoteUserRefs {
+					if ref.Name != remoteUser.Name {
+						newRefs = append(newRefs, ref)
+					}
+				}
+				fresh.Spec.RemoteUserRefs = newRefs
+				return nil
+			}); err != nil {
 			if apierrors.IsNotFound(err) {
 				continue
 			}

--- a/internal/controller/branchtarget_policy_controller.go
+++ b/internal/controller/branchtarget_policy_controller.go
@@ -37,7 +37,7 @@ type BranchTargetPolicyReconciler struct {
 
 func (r *BranchTargetPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
-	rdm := time.Duration(rand.New(rand.NewSource(2)).Intn(5)) * time.Second
+	rdm := time.Duration(rand.Intn(5)) * time.Second
 
 	var remoteSyncer syngit.RemoteSyncer
 	if err := r.Get(ctx, req.NamespacedName, &remoteSyncer); err != nil {

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -106,8 +106,9 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&AssociationPolicyReconciler{
-		Client: k8sManager.GetClient(),
-		Scheme: k8sManager.GetScheme(),
+		Client:    k8sManager.GetClient(),
+		APIReader: k8sManager.GetAPIReader(),
+		Scheme:    k8sManager.GetScheme(),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/internal/controller/userspecific_policy_controller.go
+++ b/internal/controller/userspecific_policy_controller.go
@@ -7,7 +7,6 @@ import (
 
 	syngit "github.com/syngit-org/syngit/pkg/api/v1beta4"
 	"github.com/syngit-org/syngit/pkg/utils"
-	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -42,7 +41,7 @@ type UserSpecificPolicyReconciler struct {
 
 func (r *UserSpecificPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
-	rdm := time.Duration(rand.New(rand.NewSource(3)).Intn(5)) * time.Second
+	rdm := time.Duration(rand.Intn(5)) * time.Second
 
 	var remoteSyncer syngit.RemoteSyncer
 	if err := r.Get(ctx, req.NamespacedName, &remoteSyncer); err != nil {
@@ -261,17 +260,12 @@ func (r *UserSpecificPolicyReconciler) buildUserSpecificTarget(namespace, upstre
 
 // ensureRTRefInRUB ensures the RemoteTarget is referenced in the RUB and persists the change.
 func (r *UserSpecificPolicyReconciler) ensureRTRefInRUB(ctx context.Context, rub *syngit.RemoteUserBinding, rtName string) error {
-	for _, ref := range rub.Spec.RemoteTargetRefs {
-		if ref.Name == rtName {
+	return utils.MutateOrDeleteManagedRemoteUserBinding(ctx, r.Client,
+		types.NamespacedName{Name: rub.Name, Namespace: rub.Namespace},
+		func(fresh *syngit.RemoteUserBinding) error {
+			utils.AddRemoteTargetRef(fresh, rtName)
 			return nil
-		}
-	}
-	spec := *rub.Spec.DeepCopy()
-	spec.RemoteTargetRefs = append(spec.RemoteTargetRefs, corev1.ObjectReference{Name: rtName})
-	if err := utils.UpdateOrDeleteManagedRemoteUserBinding(ctx, r.Client, spec, *rub); err != nil {
-		return err
-	}
-	return nil
+		})
 }
 
 // listManagedRUBs returns all managed RemoteUserBindings in the namespace.

--- a/pkg/utils/managed_resources.go
+++ b/pkg/utils/managed_resources.go
@@ -8,28 +8,58 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// UpdateOrDeleteManagedRemoteUserBinding updates a managed RemoteUserBinding with
-// the given spec, or deletes it if both RemoteUserRefs and RemoteTargetRefs are empty.
-func UpdateOrDeleteManagedRemoteUserBinding(
+// MutateOrDeleteManagedRemoteUserBinding applies mutate to a freshly-read managed
+// RemoteUserBinding and persists the result, retrying on conflict. If after the
+// mutation both RemoteUserRefs and RemoteTargetRefs are empty, the RUB is deleted.
+//
+// The mutation runs against the latest object on every attempt, so concurrent
+// reconcilers that each add a different ref merge instead of clobbering each other.
+func MutateOrDeleteManagedRemoteUserBinding(
 	ctx context.Context,
 	k8sClient client.Client,
-	spec syngit.RemoteUserBindingSpec,
-	remoteUserBinding syngit.RemoteUserBinding,
+	name types.NamespacedName,
+	mutate func(*syngit.RemoteUserBinding) error,
 ) error {
-	rub := &syngit.RemoteUserBinding{}
-	if err := k8sClient.Get(ctx, types.NamespacedName{Name: remoteUserBinding.Name, Namespace: remoteUserBinding.Namespace}, rub); err != nil { // nolint:lll
-		return err
-	}
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		rub := &syngit.RemoteUserBinding{}
+		if err := k8sClient.Get(ctx, name, rub); err != nil {
+			return err
+		}
 
-	if len(spec.RemoteUserRefs) == 0 && len(spec.RemoteTargetRefs) == 0 {
-		return k8sClient.Delete(ctx, rub)
-	}
+		if err := mutate(rub); err != nil {
+			return err
+		}
 
-	rub.Spec = spec
-	return k8sClient.Update(ctx, rub)
+		if len(rub.Spec.RemoteUserRefs) == 0 && len(rub.Spec.RemoteTargetRefs) == 0 {
+			return k8sClient.Delete(ctx, rub)
+		}
+		return k8sClient.Update(ctx, rub)
+	})
+}
+
+// AddRemoteTargetRef appends a RemoteTarget reference to the RUB if not already present.
+func AddRemoteTargetRef(rub *syngit.RemoteUserBinding, rtName string) {
+	for _, ref := range rub.Spec.RemoteTargetRefs {
+		if ref.Name == rtName {
+			return
+		}
+	}
+	rub.Spec.RemoteTargetRefs = append(rub.Spec.RemoteTargetRefs, corev1.ObjectReference{Name: rtName})
+}
+
+// RemoveRemoteTargetRef removes a RemoteTarget reference from the RUB.
+func RemoveRemoteTargetRef(rub *syngit.RemoteUserBinding, rtName string) {
+	newRefs := make([]corev1.ObjectReference, 0, len(rub.Spec.RemoteTargetRefs))
+	for _, ref := range rub.Spec.RemoteTargetRefs {
+		if ref.Name != rtName {
+			newRefs = append(newRefs, ref)
+		}
+	}
+	rub.Spec.RemoteTargetRefs = newRefs
 }
 
 // CreateRemoteTargetAndAssociate creates a RemoteTarget if it doesn't already exist,
@@ -52,14 +82,14 @@ func CreateRemoteTargetAndAssociate(ctx context.Context, k8sClient client.Client
 		return err
 	}
 
-	for _, rub := range rubs.Items {
-		newRtRefs := append(rub.Spec.DeepCopy().RemoteTargetRefs, corev1.ObjectReference{
-			Name: remoteTarget.Name,
-		})
-
-		spec := rub.Spec
-		spec.RemoteTargetRefs = newRtRefs
-		if err := UpdateOrDeleteManagedRemoteUserBinding(ctx, k8sClient, spec, rub); err != nil {
+	for i := range rubs.Items {
+		rub := &rubs.Items[i]
+		if err := MutateOrDeleteManagedRemoteUserBinding(ctx, k8sClient,
+			types.NamespacedName{Name: rub.Name, Namespace: rub.Namespace},
+			func(r *syngit.RemoteUserBinding) error {
+				AddRemoteTargetRef(r, remoteTarget.Name)
+				return nil
+			}); err != nil {
 			return err
 		}
 	}
@@ -81,20 +111,14 @@ func RemoveRemoteTargetRefFromManagedRUBs(ctx context.Context, k8sClient client.
 		return err
 	}
 
-	for _, rub := range rubs.Items {
-		newRefs := make([]corev1.ObjectReference, 0, len(rub.Spec.RemoteTargetRefs))
-		for _, ref := range rub.Spec.RemoteTargetRefs {
-			if ref.Name != rtName {
-				newRefs = append(newRefs, ref)
-			}
-		}
-		if len(newRefs) == len(rub.Spec.RemoteTargetRefs) {
-			continue
-		}
-
-		spec := rub.Spec
-		spec.RemoteTargetRefs = newRefs
-		if err := UpdateOrDeleteManagedRemoteUserBinding(ctx, k8sClient, spec, rub); err != nil {
+	for i := range rubs.Items {
+		rub := &rubs.Items[i]
+		if err := MutateOrDeleteManagedRemoteUserBinding(ctx, k8sClient,
+			types.NamespacedName{Name: rub.Name, Namespace: rub.Namespace},
+			func(r *syngit.RemoteUserBinding) error {
+				RemoveRemoteTargetRef(r, rtName)
+				return nil
+			}); err != nil {
 			if apierrors.IsNotFound(err) {
 				continue
 			}

--- a/test/e2e/syngit/tests/29_pattern_remove_test.go
+++ b/test/e2e/syngit/tests/29_pattern_remove_test.go
@@ -102,6 +102,8 @@ var _ = Describe("29 Add & remove policies tests", func() {
 				client.InNamespace(fx.Namespace)); err != nil {
 				return false
 			}
+			fmt.Println("DEBUG")
+			fmt.Println("rub.Spec.RemoteTargetRefs")
 			for _, rub := range rubList.Items {
 				if rub.Labels[syngit.ManagedByLabelKey] == syngit.ManagedByLabelValue {
 					return len(rub.Spec.RemoteTargetRefs) == 1
@@ -184,13 +186,15 @@ var _ = Describe("29 Add & remove policies tests", func() {
 		ruDev.Annotations[syngit.RubAnnotationKeyManaged] = "false"
 		Expect(fx.Users.CreateOrUpdate(ctx, utils.Developer, ruDev)).To(Succeed())
 		Eventually(func() bool {
-			getRemoteSyncer := &syngit.RemoteSyncer{}
+			getRemoteUser := &syngit.RemoteUser{}
 			err := fx.Users.CtrlAs(utils.Developer).Get(fx.Ctx,
-				types.NamespacedName{Name: rs.Name, Namespace: rs.Namespace}, getRemoteSyncer)
+				types.NamespacedName{Name: ruDev.Name, Namespace: ruDev.Namespace}, getRemoteUser)
 			if err != nil {
 				return false
 			}
-			return getRemoteSyncer.Annotations[syngit.RubAnnotationKeyManaged] == rs.Annotations[syngit.RubAnnotationKeyManaged]
+			fmt.Println("DEBUG")
+			fmt.Println(getRemoteUser.Annotations[syngit.RubAnnotationKeyManaged])
+			return getRemoteUser.Annotations[syngit.RubAnnotationKeyManaged] == "false"
 		}).WithTimeout(utils.DefaultTimeout).WithPolling(utils.DefaultInterval).Should(BeTrue())
 
 		cm2 := &corev1.ConfigMap{

--- a/test/e2e/syngit/utils/suite.go
+++ b/test/e2e/syngit/utils/suite.go
@@ -235,7 +235,7 @@ func (s *Suite) startManager() {
 		Client: s.Manager.GetClient(), Scheme: s.Manager.GetScheme(),
 	}).SetupWithManager(s.Manager)).To(Succeed())
 	Expect((&controllerssyngit.AssociationPolicyReconciler{
-		Client: s.Manager.GetClient(), Scheme: s.Manager.GetScheme(),
+		Client: s.Manager.GetClient(), APIReader: s.Manager.GetAPIReader(), Scheme: s.Manager.GetScheme(),
 	}).SetupWithManager(s.Manager)).To(Succeed())
 	Expect((&controllerssyngit.BranchTargetPolicyReconciler{
 		Client: s.Manager.GetClient(), Scheme: s.Manager.GetScheme(),


### PR DESCRIPTION
Move the object building logic as a dynamic function call. Which means that the mutation now happens on the latest object.