### PR TITLE
align certificate DNS names with spec

### DIFF
--- a/charts/syngit/templates/certmanager/certificate.yaml
+++ b/charts/syngit/templates/certmanager/certificate.yaml
@@ -28,7 +28,7 @@ metadata:
 spec:
   dnsNames:
   - syngit-webhook-service.{{ .Release.Namespace }}.svc
-  - syngit-webhook-service.{{ .Release.Namespace }}.svc.local
+  - syngit-webhook-service.{{ .Release.Namespace }}.svc.cluster.local
   issuerRef:
     kind: Issuer
     name: {{ .Release.Name }}-selfsigned-issuer


### PR DESCRIPTION
Just a minor adjustment to align the DNS names for the cert with the DNS names that should be resolvable, according to the Kubernetes DNS spec here: https://github.com/kubernetes/dns/blob/master/docs/specification.md

Basically, `.svc.local` shouldn't normally resolve to anything. so I replaced it with `.svc.cluster.local`.

❤️